### PR TITLE
Upgrade dependencies and use @zazuko/env

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@tpluscode/rdf-string": "^1.1.0",
-        "@zazuko/env": "^1.8.0",
-        "@zazuko/vocabularies": "^2.0.3",
+        "@zazuko/env": "^1.9.0",
+        "@zazuko/prefixes": "^2.1.0",
         "dotenv": "^16.3.1",
         "sparql-http-client": "^2.4.2",
         "xmlbuilder2": "^3.1.1"
@@ -198,12 +198,9 @@
       }
     },
     "node_modules/@rdfjs/data-model": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
-      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
-      "dependencies": {
-        "@rdfjs/types": ">=1.0.1"
-      },
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
+      "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw==",
       "bin": {
         "rdfjs-data-model-test": "bin/test.js"
       }
@@ -230,30 +227,6 @@
         "@rdfjs/term-set": "^2.0.1"
       }
     },
-    "node_modules/@rdfjs/environment/node_modules/@rdfjs/data-model": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
-      "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw==",
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      }
-    },
-    "node_modules/@rdfjs/environment/node_modules/@rdfjs/namespace": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-2.0.0.tgz",
-      "integrity": "sha512-cBBvNrlSOah4z7u2vS74Lxng/ivELy6tNPjx+G/Ag14up8z5xmX8njn+U/mJ+nlcXO7nDGK4rgaAq7jtl9S3CQ==",
-      "dependencies": {
-        "@rdfjs/data-model": "^2.0.0"
-      }
-    },
-    "node_modules/@rdfjs/environment/node_modules/@rdfjs/term-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/term-map/-/term-map-2.0.0.tgz",
-      "integrity": "sha512-z0K8AgLsJGTrh+dGkXNl/oT9vBdMei4xq1MIeGN360oimA81Q+ruQUKFCbYNRRZS03tVHPBzqXUal/DezFGPEA==",
-      "dependencies": {
-        "@rdfjs/to-ntriples": "^2.0.0"
-      }
-    },
     "node_modules/@rdfjs/fetch-lite": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/fetch-lite/-/fetch-lite-3.2.1.tgz",
@@ -264,19 +237,12 @@
         "readable-stream": "^4.2.0"
       }
     },
-    "node_modules/@rdfjs/fetch-lite/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+    "node_modules/@rdfjs/namespace": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-2.0.0.tgz",
+      "integrity": "sha512-cBBvNrlSOah4z7u2vS74Lxng/ivELy6tNPjx+G/Ag14up8z5xmX8njn+U/mJ+nlcXO7nDGK4rgaAq7jtl9S3CQ==",
       "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "@rdfjs/data-model": "^2.0.0"
       }
     },
     "node_modules/@rdfjs/parser-n3": {
@@ -291,6 +257,30 @@
         "readable-to-readable": "^0.1.0"
       }
     },
+    "node_modules/@rdfjs/parser-n3/node_modules/@rdfjs/data-model": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
+      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.1"
+      },
+      "bin": {
+        "rdfjs-data-model-test": "bin/test.js"
+      }
+    },
+    "node_modules/@rdfjs/parser-n3/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/@rdfjs/sink": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-1.0.3.tgz",
@@ -303,6 +293,14 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@rdfjs/sink-map/-/sink-map-2.0.0.tgz",
       "integrity": "sha512-5Ahs1Ky6fglsqewpo89K7CFxD4EvFvAHdI/E5HJTu0L4tCUlvnZsmyKem4iYPDWdwsKplmUdORonUz75qPgd1g=="
+    },
+    "node_modules/@rdfjs/term-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/term-map/-/term-map-2.0.0.tgz",
+      "integrity": "sha512-z0K8AgLsJGTrh+dGkXNl/oT9vBdMei4xq1MIeGN360oimA81Q+ruQUKFCbYNRRZS03tVHPBzqXUal/DezFGPEA==",
+      "dependencies": {
+        "@rdfjs/to-ntriples": "^2.0.0"
+      }
     },
     "node_modules/@rdfjs/term-set": {
       "version": "2.0.1",
@@ -345,6 +343,18 @@
         "node": ">=v12.22.12"
       }
     },
+    "node_modules/@tpluscode/rdf-ns-builders": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-4.2.0.tgz",
+      "integrity": "sha512-vSl+/38M3GKUV2mJ5HXfCxLUkoI3baRrBgLZnCKQPQUsptxzQGRxxIKFVHIIC3Dv+VA6V21/XLPl5Hik+nyRQQ==",
+      "dependencies": {
+        "@rdfjs/data-model": "^2",
+        "@rdfjs/namespace": "^2",
+        "@rdfjs/types": "*",
+        "@types/rdfjs__namespace": "^2.0.2",
+        "@zazuko/prefixes": "^2.0.1"
+      }
+    },
     "node_modules/@tpluscode/rdf-string": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@tpluscode/rdf-string/-/rdf-string-1.1.0.tgz",
@@ -377,9 +387,9 @@
       "peer": true
     },
     "node_modules/@types/node": {
-      "version": "20.8.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
-      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "version": "20.8.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.8.tgz",
+      "integrity": "sha512-YRsdVxq6OaLfmR9Hy816IMp33xOBjfyOgUd77ehqg96CFywxAPbDbXvAsuN2KVg2HOT8Eh6uAfU+l4WffwPVrQ==",
       "dependencies": {
         "undici-types": "~5.25.1"
       }
@@ -398,6 +408,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__data-model/-/rdfjs__data-model-2.0.6.tgz",
       "integrity": "sha512-Xcz25z9AapM1YZ/RWM9hbSTGKC6l8CkYTaE3ZXObCxa1y5j++jhvQUfECjgA/0ikSMpD6dRSLMG0m5PYN+kfNQ==",
+      "peer": true,
       "dependencies": {
         "@rdfjs/types": "^1.0.1"
       }
@@ -406,6 +417,7 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-2.0.6.tgz",
       "integrity": "sha512-dkMgQMDb1V/uiNYt/uG+/56xMqEHZyBdInod/oTpUrb9xJ2Q2vHuQKQNphCYHEMm9+ELtZAePKDX1ZeB0/vWrg==",
+      "peer": true,
       "dependencies": {
         "@rdfjs/types": "*"
       }
@@ -414,6 +426,7 @@
       "version": "0.1.9",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__environment/-/rdfjs__environment-0.1.9.tgz",
       "integrity": "sha512-u7NUsgI2r0X06JXY8lMqcvEpgjVv1eL8lh//CGRsN6ovgA5RKYiTjedU80No21vPU/LEQ3wB8fJ5diMPy+IDDw==",
+      "peer": true,
       "dependencies": {
         "@rdfjs/types": "*",
         "@types/node": "*",
@@ -490,6 +503,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__sink-map/-/rdfjs__sink-map-2.0.4.tgz",
       "integrity": "sha512-B0y6Hu02VvceUW7dkRLW6+acCXBQPt+yIha234ogHOe9FnDLz2U9SDZwvh+9YECbqmEEY/NA2d5y8vNtAhtt7w==",
+      "peer": true,
       "dependencies": {
         "@rdfjs/types": "*"
       }
@@ -498,6 +512,7 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__term-map/-/rdfjs__term-map-2.0.8.tgz",
       "integrity": "sha512-Rk2G68b26VBZi7ecFHd/Q0ot1FT7cu7Ae6Po+4ycWRk/r4RqawsQIRpixetnl55Y66kUzwtUfddsfOWZ3mEMXg==",
+      "peer": true,
       "dependencies": {
         "@rdfjs/types": "*"
       }
@@ -506,6 +521,7 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@types/rdfjs__term-set/-/rdfjs__term-set-2.0.7.tgz",
       "integrity": "sha512-qPADoUsOv5CgLXRtEPuH+Yjbtk2IVCw44PRKYebUmSCvsaXXmY0cQz7SeKBGVO0F+OQ3CuA263xVur/QyWDgSA==",
+      "peer": true,
       "dependencies": {
         "@rdfjs/types": "*"
       }
@@ -535,531 +551,17 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
-    "node_modules/@vocabulary/acl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vocabulary/acl/-/acl-1.0.1.tgz",
-      "integrity": "sha512-zGf4PngXLP6KEnD3iDlbxqzcwatdVNhxgyBbC5M+HwmiOtdYG3i2MvEY4HnSebJOaAVaGzeluSs2eoc76+wPUg=="
-    },
-    "node_modules/@vocabulary/as": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/as/-/as-1.0.2.tgz",
-      "integrity": "sha512-L4vSUdnTeAvCrTvFrwrNWom0swdROmdiXeh4i6nbNx9LANA/br4CwHAyBHfYfgg88x7AVaJRX7fphEcVM2093Q=="
-    },
-    "node_modules/@vocabulary/bibo": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/bibo/-/bibo-1.0.2.tgz",
-      "integrity": "sha512-yAp8vQvQ3CwvBiH5G+XodRdV4YDsg9u0u4rJoxhqGk3q0hR6i3yLiLgdCUb77LLHicXD+HUC9FNfJ29OR8KPtA=="
-    },
-    "node_modules/@vocabulary/cc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/cc/-/cc-1.0.2.tgz",
-      "integrity": "sha512-4Alfe9crKv1pBymw/iqHLZa88wVPP9xYe0hhYUYY+AIKRWU+kfA/nwcvYhIU1JvZxPYmeH8GLSu7Oby0Rw3p4A=="
-    },
-    "node_modules/@vocabulary/cert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vocabulary/cert/-/cert-1.0.1.tgz",
-      "integrity": "sha512-PWjuMx/HRWubaK0we66AJ3PwXDz/9w3TmVidZePdFM50g2WE7L7OZOGskqFrLzxgUPl1F78Bc7vl5f/LRgVCMw=="
-    },
-    "node_modules/@vocabulary/cnt": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/cnt/-/cnt-1.0.2.tgz",
-      "integrity": "sha512-/UCZjhTi8mT2RWivwPpY4/4Y47PvqibmCiGOOh7K6/xX8d6su61oL6W/hwLf1pCNaiCIKYT5hVUdL5+rGRlf5g=="
-    },
-    "node_modules/@vocabulary/constant": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/constant/-/constant-1.0.2.tgz",
-      "integrity": "sha512-gE9SbdTA4lqWfzkHUu+Kof+bINYup7EsMvsDTIKb27LZg44EaKUy1ckVMArjx5UOwjrTw3u1O0piyAu7FNC+aQ=="
-    },
-    "node_modules/@vocabulary/crm": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/crm/-/crm-1.0.2.tgz",
-      "integrity": "sha512-9pB6HfHm0UyK5WGVjcppsBXCwOwhWF2PVJ+0pUzRuZ+IRcAKpKsfRZX3bdA/lMgn51wYFsb4JJIxB77csG/hyg=="
-    },
-    "node_modules/@vocabulary/csvw": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/csvw/-/csvw-1.0.2.tgz",
-      "integrity": "sha512-Gb3TNVsLL7l5og9/Kh0tLC4WxIRBsNJzy4abUn9k4LsZh+m2lO6fzA37lachWNX/8J0Njo9edZFQRuCu3SXVnQ=="
-    },
-    "node_modules/@vocabulary/ctag": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/ctag/-/ctag-1.0.2.tgz",
-      "integrity": "sha512-487Y2p7tyfC9vYkZPhSgy099Qsl6na9SRIGaEQ/ml4zQhw6WTbPmuEcisMcBmfkqlPb9fn6GhQXCeVwdHAitvA=="
-    },
-    "node_modules/@vocabulary/dash": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/dash/-/dash-1.0.2.tgz",
-      "integrity": "sha512-XAnAuhdj7FxaK+c/hlSV17lh0mcTbiD9qMfUwCt/Japr/pcer0fAKPoLEhFjPLQLfDAv2Ud63DO7NC2JKZm2tA=="
-    },
-    "node_modules/@vocabulary/dash-sparql": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/dash-sparql/-/dash-sparql-1.0.2.tgz",
-      "integrity": "sha512-ZIp/D8SEfjHNYY0en4ijvwawoWJLrMA2w0hUL3Okdp/PKQmEQXAN4SPl9oz+N0Aaj5RGhD9nPA2iEhmGuXqczg=="
-    },
-    "node_modules/@vocabulary/dbo": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/dbo/-/dbo-1.0.2.tgz",
-      "integrity": "sha512-y/NU1O7KVUJPXRIKQ3q9N9K57dyPacO25aR4pxQptY4WXFJqMWGjVxRKEAqipZw7wGm1il0cFv45dBi2KMCpgg=="
-    },
-    "node_modules/@vocabulary/dc11": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/dc11/-/dc11-1.0.2.tgz",
-      "integrity": "sha512-w0JA2B3GxwnsLn/4z5WeuZuMk2DCi3M9MNpwa6A8RMbysvkiJHzSdIxohturV4+T5peBzLMEnqFbJFsqn3byJA=="
-    },
-    "node_modules/@vocabulary/dcam": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/dcam/-/dcam-1.0.2.tgz",
-      "integrity": "sha512-c6Q51eu+y2znnlLOs/NQNEOD1FPA3E6b+zCpFpQ4Ouqo4J+fl50LJZF+UTSOPvecaEDh5CFCfICjv98nh9jQ1g=="
-    },
-    "node_modules/@vocabulary/dcat": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/dcat/-/dcat-1.0.2.tgz",
-      "integrity": "sha512-h496KzF/N4FyLd2cEQLZXZ4unbSyEBb5ETnPkRtWwNlAdT1JCHCqEs2jPoS4Dp/CHV6JmHrbJYLU/8SwfmvsTg=="
-    },
-    "node_modules/@vocabulary/dcmitype": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/dcmitype/-/dcmitype-1.0.2.tgz",
-      "integrity": "sha512-MNc9zPFz4mHhU535zQU4vT2ebQwNQ/RyOFe7s+BUcfw2RCAmLH1mK1YFI7so9ngXx8HAC0iDfMwSV0FpcFBrFg=="
-    },
-    "node_modules/@vocabulary/dcterms": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/dcterms/-/dcterms-1.0.2.tgz",
-      "integrity": "sha512-XFe5NLoejzrHoIbxegztg12ag2Bg+/fycBI4rfRVkDgueKJS2rBj+lYmwP0xkzy815wLqhw7Dox5HMhYUkWftw=="
-    },
-    "node_modules/@vocabulary/dig": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/dig/-/dig-1.0.2.tgz",
-      "integrity": "sha512-Y5DaEpxvKu0fKmGJpASSq3TSFucTCNOlmt/uffirtNVdjV2sYfOuZ+PwTHYbGFJNAqN9rpns1hdANA4MjggdrA=="
-    },
-    "node_modules/@vocabulary/discipline": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/discipline/-/discipline-1.0.2.tgz",
-      "integrity": "sha512-BIocTlodM33B+T5L03nf0OFdLSLkZQZWNtUFbnOojIAfC3o6sNUft7gpUw2FsbDXLEM9ANbi7hNeiweyj5V2JA=="
-    },
-    "node_modules/@vocabulary/doap": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/doap/-/doap-1.0.2.tgz",
-      "integrity": "sha512-dMekFHGjzQItNtrTSifGKPS5sF2edk1GNMXgxxHFzYbACZaxD93V0wyOe3qgqDrBfI3Hhy25KwkIipJKemeq3A=="
-    },
-    "node_modules/@vocabulary/dpv": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/dpv/-/dpv-1.0.2.tgz",
-      "integrity": "sha512-gSv/k/S2X4F9ikSK2f5mMvEo0jXaA0/3cXDYsZ2roRLeDVDpvIixpk7/NPZNWKdHj+5TNsWWOaVyFlAvTrlElg=="
-    },
-    "node_modules/@vocabulary/dqv": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/dqv/-/dqv-1.0.2.tgz",
-      "integrity": "sha512-DgmiB+QGlVnrBMZIkEe9T4rsfERoRvkUDL0gk/dvmE+vlQH5ENINcAHuFH0MC5UnOVl7ctjWQjqxfszpif3ekQ=="
-    },
-    "node_modules/@vocabulary/dtype": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/dtype/-/dtype-1.0.2.tgz",
-      "integrity": "sha512-CYtvCDKSnWBPepHEy1ZA7GRS0uSP/t3i/pg0rL2WZz08QsCxMNFNi/orLkX76RORUyAg7gJqI6fuNxb7GiXrTQ=="
-    },
-    "node_modules/@vocabulary/duv": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/duv/-/duv-1.0.2.tgz",
-      "integrity": "sha512-deg+8G/zzUZdevOyH5a/flmT3jGalg3Peiuf14lUEOLhebjXWWHFY7cMMkyvVEfj07V4FC24TeTHtKsPfYLydw=="
-    },
-    "node_modules/@vocabulary/earl": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/earl/-/earl-2.0.2.tgz",
-      "integrity": "sha512-PecS1aPHtrE6iSTuZgXEc3J3KanIwfg7Qh9wbXXUcExSYZ+0OzzAOVQeWHfAnRo13bCPS3UlxOnDEAcZvz3cxw=="
-    },
-    "node_modules/@vocabulary/ebucore": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/ebucore/-/ebucore-1.0.2.tgz",
-      "integrity": "sha512-9q/BVbcI2J1J32aa6HJEP46g1i6JMzp71Dy0ds41jqmblmWYqNmk8gfgBJCp0ImllRcMniYhR+q6CghBz+Pp9w=="
-    },
-    "node_modules/@vocabulary/exif": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/exif/-/exif-1.0.2.tgz",
-      "integrity": "sha512-QgMynz33XmpdG7kw66Jb1CGaAjX8y2L6vJVRz8DJ2lr+wUvf6RYzjVok/MkS+ou9+VEqZ0zbYo84mShWvGm1jA=="
-    },
-    "node_modules/@vocabulary/foaf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/foaf/-/foaf-1.0.2.tgz",
-      "integrity": "sha512-zQcjNHeeG4j7Rkxu50wqWcm1hyeqk0ZTyoQ1sAbNbJrs7s0Afanqvqw4GxL6YwF1Vp38Zk86W5VxNYnEQI/PSA=="
-    },
-    "node_modules/@vocabulary/frbr": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/frbr/-/frbr-1.0.2.tgz",
-      "integrity": "sha512-Nu5njOEMPpZkWwMPCBLsr0UFqEHg6Sh3yVFUj+s1DJHU1SfQ4PLRA5lBSczYsoiQ/4mYHrbo8Jwrw1RmD1mrWQ=="
-    },
-    "node_modules/@vocabulary/geo": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/geo/-/geo-1.0.2.tgz",
-      "integrity": "sha512-rMGmbMzcbVlU8mNWDxJZ3Qk8PDeuhwHeCz34Jbrc59GKba9uz1eTWJx3M78oEdX8DF/bRGOKu/Gt+bP+Ly2xVA=="
-    },
-    "node_modules/@vocabulary/geof": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/geof/-/geof-1.0.2.tgz",
-      "integrity": "sha512-JvJPov4dKuil6Kp29XD5D2wP0ZQubijCcL14Ax570GIu1cK/SX2lJfR3T7RyS2bV/ojBKmabV+a8956g931MsA=="
-    },
-    "node_modules/@vocabulary/geor": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/geor/-/geor-1.0.2.tgz",
-      "integrity": "sha512-YFb+XTW1uRsiOjhWw0u+JwtKIkfk9GHWx0QJXmG97+O8ed7gKVF82NDN4NkaL1h+8Wsc+KvCZFZVOv+JJ7N8ng=="
-    },
-    "node_modules/@vocabulary/gml": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/gml/-/gml-1.0.2.tgz",
-      "integrity": "sha512-3THxTSJ/GDUQGgH/OYCLNso7veSGrLevFOrHlG6cxL5GZWAlXnirGGnsTSOY6YIFUR2pveRDwxyiRAcUMnSkmA=="
-    },
-    "node_modules/@vocabulary/gn": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/gn/-/gn-1.0.2.tgz",
-      "integrity": "sha512-baRl+Ah18TGH6f3ufOY5DHZmTNGUOB996StJZNkRRPmec5uXFlm4jNEl9E0P1kFZXH/3SZf4ewuAe3wzedNGLg=="
-    },
-    "node_modules/@vocabulary/gr": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/gr/-/gr-1.0.2.tgz",
-      "integrity": "sha512-G2UgHg4QW/YB/9PEs2y6XB1l53t1UAzBgMJKmcnhkOM9jPPF9YEG5mgvK6OphC1D/o8oFnVK3hmmzJQj+TVnsQ=="
-    },
-    "node_modules/@vocabulary/grddl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/grddl/-/grddl-1.0.2.tgz",
-      "integrity": "sha512-PLdZ1VSWWklkU+fNJV3uSFXNFtrB4lLTLUMUO8Mb4OXyGUKXZunb/fbBOqBjynjTme8yZ/uLiU4rSgrA8ZKZdQ=="
-    },
-    "node_modules/@vocabulary/gs1": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/gs1/-/gs1-1.1.2.tgz",
-      "integrity": "sha512-tsjdfaShHx1jWz5hzobcODp7UGnsxLdUQug3iPVwQvibfXEdmOKTOpFpuwAVi2JzafMzN77qFH62nuG8N/BfKw=="
-    },
-    "node_modules/@vocabulary/gtfs": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/gtfs/-/gtfs-1.0.2.tgz",
-      "integrity": "sha512-xIFhsU/mNcNAubUgpC5uUitKMQ7BQIbdvl26RGHemHd4rElKtkzt5y8z0r2hnmvCDo72qFyK2XfU2ndb1m+gNg=="
-    },
-    "node_modules/@vocabulary/http": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/http/-/http-1.0.2.tgz",
-      "integrity": "sha512-NhyYxC+Th5QDJfU5J6W91Oy0DWubro1F90OI7GyY7Tp7kZbC6o39vsKFIoY8QoPtUY8mUghNGb0WGrh5rdWKQQ=="
-    },
-    "node_modules/@vocabulary/hydra": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/hydra/-/hydra-1.0.2.tgz",
-      "integrity": "sha512-RIzOjYCQZGch5wHxJB7Vn7y/ianidIKLTK3nAgJ0Gdr3YEX05NJx9sduxbH7duDQnNaNPtjzAQH3LJ+eM7pZ8w=="
-    },
-    "node_modules/@vocabulary/ical": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/ical/-/ical-1.0.2.tgz",
-      "integrity": "sha512-wx8fFRltWb+d1iQnifvPQEwixENqWx+a28/W5T3L52hX/8wy/Ft5HOEF6OhUweajSzMkelJbmJpU1xXM+gXCbA=="
-    },
-    "node_modules/@vocabulary/la": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/la/-/la-1.0.2.tgz",
-      "integrity": "sha512-jPScZ6/j12nntpr1QDuOZ0qL6EmpZsYMAg6EYF+s7I3jWm8tQQYEeW3vUDvd3kKWn9zkVV2u8iisZjXnribwgQ=="
-    },
-    "node_modules/@vocabulary/ldp": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/ldp/-/ldp-1.0.2.tgz",
-      "integrity": "sha512-DVgLR738toEFUPC6RKp4XJcn+U/PvHQaAXnRUJVRkofPa+xNrtmGtieWJjEU1RLGAiKWtF9tQkahbXnoHjDErQ=="
-    },
-    "node_modules/@vocabulary/list": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/list/-/list-1.0.2.tgz",
-      "integrity": "sha512-jpGcXTmfwRbTg+sq98k2CiPz5hT/qwDwGTXleEVSz84j8Fan/ArsuluTeg4NxHtxBmCJVVGdk2HVnqN2SEzjxQ=="
-    },
-    "node_modules/@vocabulary/locn": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/locn/-/locn-1.0.2.tgz",
-      "integrity": "sha512-cXMTt+pIj4F8LOulx2trp9NuJUUq2DFt0m3BV8D6NLEg7lcP2RA+keuk0xtx24Q3O5NeQkuYgJeFGkpq2u58yw=="
-    },
-    "node_modules/@vocabulary/log": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/log/-/log-1.0.2.tgz",
-      "integrity": "sha512-KTnrYtmzCyLej+gBsUlamm53TpOc+m/A82Vevw8tK0uqldP4CfVo1R0fUb2B64O4DsoE4jcOpS4PgJ1s7005EA=="
-    },
-    "node_modules/@vocabulary/lvont": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/lvont/-/lvont-1.0.2.tgz",
-      "integrity": "sha512-YMY3gVzWsH6TUwNTSaI/eNpYHzrzshbLpT2/NG5q9/YACOKSu20JFPP27/l3y+J2FOiyvqPzRUMt2bD//2izLA=="
-    },
-    "node_modules/@vocabulary/m4i": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@vocabulary/m4i/-/m4i-1.1.1.tgz",
-      "integrity": "sha512-P9jo9gkRrYgQZq7ZCzrzAQklkOucg+YUEfNGKNfFJvebx0TOtZUySQQyxJsNjXar8Bi3qTur8NSi7v6vBfhwAg=="
-    },
-    "node_modules/@vocabulary/ma": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/ma/-/ma-1.0.2.tgz",
-      "integrity": "sha512-mCuAMPb3v5Gpmzx8pakW+fA/yJP3oNW6u+fYGZP7xJDMoQGCsSFPRv6FkGjpyPSm9FbJ32tJSiM3JpQ7qg8Suw=="
-    },
-    "node_modules/@vocabulary/mads": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/mads/-/mads-1.0.2.tgz",
-      "integrity": "sha512-fi4xu7IlcTnnluzxGYr4T34E+Tl1COFozyJDBHhKLumt3RZuE56X4/g1gsrNTOlYldlFKgcaEOPPsfISfj2Q+g=="
-    },
-    "node_modules/@vocabulary/math": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/math/-/math-1.0.2.tgz",
-      "integrity": "sha512-o+WP8BoQDUMix7r34VJZru1oHY3vagjp9/aZEptnCNGt4kEmgX25W/Pv/QN0XUqS7fJitoZg2ay46FreQ5yU/g=="
-    },
-    "node_modules/@vocabulary/oa": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/oa/-/oa-1.0.2.tgz",
-      "integrity": "sha512-UlG2mdz+1wa8qlHjGMYrp2mkJzIldygrbA3+xZGArc6H1RlI4ZRb/WrhVldWLbFwHm+Za4CUa4T5Az9fh/BYew=="
-    },
-    "node_modules/@vocabulary/og": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/og/-/og-1.0.2.tgz",
-      "integrity": "sha512-xd9mF/d3CDhb7LQLtBSrYejwkq8fZg2X5gu+EUmMyHDMvhiHgPvtv2yhI85TZdwjxsX4tvmfqm9mhv/8l1OCMw=="
-    },
-    "node_modules/@vocabulary/oidc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vocabulary/oidc/-/oidc-1.0.1.tgz",
-      "integrity": "sha512-rE+n+Q1WZhBDG3WiGg4RFJ0JnJBd4ySg4p5WL1qaHkkSeaY1VNzjLxJuH/LWaPw4CzT5ybNHJAYWxcUcqzaILA=="
-    },
-    "node_modules/@vocabulary/org": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/org/-/org-1.0.2.tgz",
-      "integrity": "sha512-ZyQsU5IPIHl1WebJ78KiB9d2z2a7jG2pTRS4+qZrKPjmns02CAhFCvOIo+445rNKVK0OJPQKeEKRFvzJKvbi6Q=="
-    },
-    "node_modules/@vocabulary/owl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/owl/-/owl-1.0.2.tgz",
-      "integrity": "sha512-bsnNM7Utan6fpwaAEOxXqo/vr76sv97Cn3WxQvfHM46bdnym2qXvXCtrpUZJ1rONlZaDtOzwdnEFvcMsEy1TdQ=="
-    },
-    "node_modules/@vocabulary/pim": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vocabulary/pim/-/pim-1.0.1.tgz",
-      "integrity": "sha512-kK2LxOKRpz62VRXEJJ1q2zbW7z0dyFAylLNzlU+hOyQJ+D84oLl0PpXviMUlsfCUfSSOrFmv4DmaCDM9z0qEdQ=="
-    },
-    "node_modules/@vocabulary/prefix": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/prefix/-/prefix-1.0.2.tgz",
-      "integrity": "sha512-X+K9eop4T9LLEvKzVf2yYIVXH1WchbLu9vyP4SM7jNh4/IcPS5n0YcRw2SycsitKoylrsWyj0ur4kDMgtonbUA=="
-    },
-    "node_modules/@vocabulary/prov": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/prov/-/prov-1.0.2.tgz",
-      "integrity": "sha512-t3ZB7VyjBCCmbWdj+jt/SsE3ItJ1bVpZfi8LB7+ZFXwmNwbPM75GCQgtnIfVMFSl9BZNy9DiNOzmYo+KcbTOZg=="
-    },
-    "node_modules/@vocabulary/qb": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/qb/-/qb-1.0.2.tgz",
-      "integrity": "sha512-xcNUJxe/FrjIcAmKw3vkBYmgLqzMZFACrhSlNvoBJdCDm/G7vBczMigGqOHilffq1BIjAO3zQ7VAiZATtYoa+A=="
-    },
-    "node_modules/@vocabulary/qkdv": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/qkdv/-/qkdv-1.0.2.tgz",
-      "integrity": "sha512-TSkK74YnbaXzRkrTc98/hokHQ0/vBRLiMqeyAMUZAi0LJg7ZC1hjw36tijxL7Exg+b54jz3uMqBWGk6LFEjWaA=="
-    },
-    "node_modules/@vocabulary/quantitykind": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/quantitykind/-/quantitykind-1.0.2.tgz",
-      "integrity": "sha512-Xv757ZwUbJaI6/EU0F+Vn+JoY/JWw+zb947pqKULCp9mr/XBL7iHoHj0fAmVJj3CYUTc5+9JlFoVdv755KWBLw=="
-    },
-    "node_modules/@vocabulary/qudt": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/qudt/-/qudt-1.0.2.tgz",
-      "integrity": "sha512-m56oA0tsi7B/C+FITiWYOMkq+GopbI8eddUr6N/QwRjc1LPYAM4RKpD54h+Wo8g0DfUv+UUe0yDDFsXWAEqzIw=="
-    },
-    "node_modules/@vocabulary/rdau": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/rdau/-/rdau-1.0.2.tgz",
-      "integrity": "sha512-ImTDNwnDV3dAfvJUP4LrNHEIelJ2lkeqde7bBP3bjRkYACyrsSnb7t21Y2xUTk4oC5jsjGj4x5T33ThYmROsHQ=="
-    },
-    "node_modules/@vocabulary/rdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/rdf/-/rdf-1.0.2.tgz",
-      "integrity": "sha512-lozo8HeTrncUA3m6zqQwymk875zKUmd5BaOW5M9VEf5sZteNV/wZ2hpytkBWQRbM1scqDq5M6uFVrMvwRLkdbw=="
-    },
-    "node_modules/@vocabulary/rdfa": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/rdfa/-/rdfa-1.0.2.tgz",
-      "integrity": "sha512-Igjb/h8efkKBUN+sgq1JK/9XwPDZLU/UpzWmtQX+6Am0iGPI2Dz1gVXqcEPzW/3Ph4Gcuk0vQPTa44b0EW0FPg=="
-    },
-    "node_modules/@vocabulary/rdfs": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/rdfs/-/rdfs-1.0.2.tgz",
-      "integrity": "sha512-nIwJ08+X33CyyReaE4iuA1iMyYCNI9u9OFTDf4FucNmEVvLjJdxJnMT5nz1gZuFuEiS6xsw4QS17xJLWUMokvg=="
-    },
-    "node_modules/@vocabulary/rev": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/rev/-/rev-1.0.2.tgz",
-      "integrity": "sha512-QL9tk91NyIQWMsOQRrOgR9x7NRTZ6F8YNA3UkUr7vMFFrB0CuWO1fk4U3fsPiPQCufoSa2dUYj5nPdqY6D6p8g=="
-    },
-    "node_modules/@vocabulary/rico": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/rico/-/rico-1.0.2.tgz",
-      "integrity": "sha512-mMwO00wAMJ1VPhfl6oLYxaJw5O8kND4oBL2UdkaJ4xDFggn8sJ1ausgOgjbyRbFCz+5cHY4kxWLUXZ0TzImYDw=="
-    },
-    "node_modules/@vocabulary/rr": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/rr/-/rr-1.0.2.tgz",
-      "integrity": "sha512-tXxRihBV3TtJxKzg5VXjeiMAJ23YdrijlvXMipqbwXCDxExVWe3t9jNZenw2yZ/bjDMionZHgnrEY+B6xXJl3A=="
-    },
-    "node_modules/@vocabulary/rss": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/rss/-/rss-1.0.2.tgz",
-      "integrity": "sha512-DNBUsXHO3nnMNhdj/GD4un+dCAiL07DgOys3l377IOFypf2LPCCfBjqx4deWLUXOtbnCtKV2WqRKbUxmd8trUA=="
-    },
-    "node_modules/@vocabulary/schema": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/schema/-/schema-1.0.2.tgz",
-      "integrity": "sha512-fXSYjivQnnCx29udegcoxKfj0+hSytYA66HdkK3QhmRWdwQ66bSnG0mTDAwLgvi9ewSVvNAeAUJ265Zq/8N9oQ=="
-    },
-    "node_modules/@vocabulary/sd": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/sd/-/sd-1.0.2.tgz",
-      "integrity": "sha512-LdBFdJAwJ4B+ofYtDdoyc51T3AmhcLHnHHndKHVDU9kr592Z7ohpAJbYvLbFXmeTllWix6iygkyGktQwi8dKxw=="
-    },
-    "node_modules/@vocabulary/sdmx": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/sdmx/-/sdmx-1.0.2.tgz",
-      "integrity": "sha512-bAwUgehx8h4soTjYXDfqKPuWOjktbicuuVFYgitYw2eW+ATn/BZHt2TFLbVq8JSU7KD0GcJeRde9rA3FN19giw=="
-    },
-    "node_modules/@vocabulary/sem": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/sem/-/sem-1.0.2.tgz",
-      "integrity": "sha512-4amt8BUcgzJpDv9lfQeFOnI90s0sdXvrVTfO62IECdr5sRHre5iNKSYgvEnX26CdfMspdJmoAHDTLRSJ2o71oA=="
-    },
-    "node_modules/@vocabulary/set": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/set/-/set-1.0.2.tgz",
-      "integrity": "sha512-8cWQmMyqGwGuvsUV0dNZj/+aGgBZK90KlM0UaTLojTFqnjxg04VnWVrTamtkNQKQXgdJAvbE2lSqq1SWlI/+8Q=="
-    },
-    "node_modules/@vocabulary/sf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/sf/-/sf-1.0.2.tgz",
-      "integrity": "sha512-5fyBBXskuNbTZf0xnPywYokXvYRM3+pOnCHo4h8IfMdpUoB8QJ4XfxTktlvyIYoPsf5aMiBfYudapkorHgpTOw=="
-    },
-    "node_modules/@vocabulary/sh": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/sh/-/sh-1.1.2.tgz",
-      "integrity": "sha512-1hXJe79ipXJbo/ywVGdefEcHPutedK2ilZv9G6op71wTibeUlCe1ik9OvnSeyH42RfLHqDs2vLvK3zH50RZS+w=="
-    },
-    "node_modules/@vocabulary/shex": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/shex/-/shex-1.0.2.tgz",
-      "integrity": "sha512-n2pBiLYcXiEBurwZQVjYJrn0MOZaaB3RjzUwOIzJU6KpsFcR04Qwfs6DHItH16HwdHUsfbuu+LqsERyfrl5+Ig=="
-    },
-    "node_modules/@vocabulary/shsh": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@vocabulary/shsh/-/shsh-1.0.0.tgz",
-      "integrity": "sha512-x8O9CpT3bTPU2BTeBm/tDpYxhkZ5Rfb1FVkJAQEA1MoHixUJcMcIEyBUJixcStx4sEVLos+29yKBW+rxqt+fRw=="
-    },
-    "node_modules/@vocabulary/sioc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/sioc/-/sioc-1.0.2.tgz",
-      "integrity": "sha512-jasDMFX6FE3NfLrzyQTIIZ7SaYSiw7foeSd9V3RLMNVdnGb+TdSA5tTc6IdO+shBL6y/bV89fqSrFhDBQkJ/1w=="
-    },
-    "node_modules/@vocabulary/skos": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/skos/-/skos-1.0.2.tgz",
-      "integrity": "sha512-qBP6d0lRUkReSbmn0Ca2h5aOPm+pbDXnTImbyn4uYadWzo+2N2D0i72bBe4G3CVSUtZ60DtqbzgzJLuGuimJlw=="
-    },
-    "node_modules/@vocabulary/skosxl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/skosxl/-/skosxl-1.0.2.tgz",
-      "integrity": "sha512-4WA1+f3uuwK0IlXvHAjhiPchSlmK04hO5rflNT8iIqYvKrk+st2RA6IeuWnT3Ra+6MXrr+3xChH6nI/z1D25mg=="
-    },
-    "node_modules/@vocabulary/solid": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vocabulary/solid/-/solid-1.0.1.tgz",
-      "integrity": "sha512-3X+VVGHbCPEiMrUqr1NL6AW/aITS6Gvu3PUlty46X6qMlpuQkWt6t5bzsmppJ2MMmzDWEijFLgAnh1hnzsJ6SQ=="
-    },
-    "node_modules/@vocabulary/sosa": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/sosa/-/sosa-1.0.2.tgz",
-      "integrity": "sha512-D9TkfzenKqwpc4JYd8Ww4ViU2sgkaI8YXBwOfqBGdPsZcVEYvyBgJayL/Pfa7yiBwgTD5brCZyiZnHz4K4WQXQ=="
-    },
-    "node_modules/@vocabulary/sou": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/sou/-/sou-1.0.2.tgz",
-      "integrity": "sha512-5/NyPD686hdrBdT2/amErDpgfXMsbqyXeMJythjNcC064Z4cr25JK6IdL73Q7ZoaocBf0t+mOoN7rIVyi6hTjg=="
-    },
-    "node_modules/@vocabulary/ssn": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/ssn/-/ssn-1.0.2.tgz",
-      "integrity": "sha512-ZCTWWMBULgdw164Yq4Eg2lrXPE/uKQBWIJ2pnd2CsTjYkc2+gDqEEM8PQmBfLuYpCMxIV7Pp+3gtXwUpAUz/ew=="
-    },
-    "node_modules/@vocabulary/stat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@vocabulary/stat/-/stat-1.0.1.tgz",
-      "integrity": "sha512-DK7Lst7Kovi5Jbo5pEDYtyRNYorac78iKPhhajsd9Yv1pBgIdYYwxxOUPovOMr3ia0NOoApOeyZC8bWli/vDKg=="
-    },
-    "node_modules/@vocabulary/string": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/string/-/string-1.0.2.tgz",
-      "integrity": "sha512-H1OalOpXwA7DgFqYcA+Dbd7vAmXZuhO1KjFgnBxxH4y+c4R1qG2HaHd40sz6ayPf8DpOoOXJ46ZBuFnTksKgiQ=="
-    },
-    "node_modules/@vocabulary/test": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/test/-/test-1.0.2.tgz",
-      "integrity": "sha512-iUme+7SK5xVj/ygYWpgdqhrrHtqzI0MhOOivLOBgmG/aWjd3lxNHmAbOdxJbU/kVL5N4w/NaDJKoq5mDStWlcw=="
-    },
-    "node_modules/@vocabulary/time": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/time/-/time-1.0.2.tgz",
-      "integrity": "sha512-d9BZoqXtgSmMPrDOhPuWUhQYVQdMKAct7Ge0StgbmcoI9XfAfS4HTc2vgtCe5WKaF+1KQNyhAo6yhynl0WO6mA=="
-    },
-    "node_modules/@vocabulary/unit": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/unit/-/unit-1.0.2.tgz",
-      "integrity": "sha512-cdec4YMNbl/8+X+ciOWXquBEZOcNoRP5zPlKX4rV34l3qAmChUJQUCc/JWYzdKQTfhFkJKisyqNq5MPaF0rnjA=="
-    },
-    "node_modules/@vocabulary/vaem": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/vaem/-/vaem-1.0.2.tgz",
-      "integrity": "sha512-ma0n5IlgbGnQdaXCUDd44Anat/Rp9rAU8V44uEUJakFBZS8Gr3GfpzmJVUtMvfFDes0yiibatJfyEHnzG211Hg=="
-    },
-    "node_modules/@vocabulary/vann": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/vann/-/vann-1.0.2.tgz",
-      "integrity": "sha512-/soY75MisKtnghp00zJLD7fLsEexp5iYgkspQHmCcA9z1NOwEGwwwckdCC3L0+5IGnaPH48EqkhJdzEQ9FVCoQ=="
-    },
-    "node_modules/@vocabulary/vcard": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/vcard/-/vcard-1.0.2.tgz",
-      "integrity": "sha512-tk1bScvz0GaDZdtvrdTa2r4b7d6l6EUY65giVMdHRUurns/sARx66J/g88SkaucqeQaZPnLrCGOEDbPsDNf6IA=="
-    },
-    "node_modules/@vocabulary/void": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/void/-/void-1.0.2.tgz",
-      "integrity": "sha512-a2mG69bQ8tPQv1xEHvsxZFdiubod/QwWTxzWZxNk8qFUeZr86/FVODxgc8jSLzqhbmA4qTmi02JmwD1gxO5Cug=="
-    },
-    "node_modules/@vocabulary/vs": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/vs/-/vs-1.0.2.tgz",
-      "integrity": "sha512-QDhCjZF4s1JB9lXBYCSieSe/hTuB1p3Mq7yni77W4EtENCRtIleMptk+onH4bnhQQYhLxmZG+l/a3a+krMLwlg=="
-    },
-    "node_modules/@vocabulary/wdrs": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/wdrs/-/wdrs-1.0.2.tgz",
-      "integrity": "sha512-rUdzYNJPy6GN/3KeD2tdiUCaTmY2hGlBcAdyn7WQD8aafIdIUhcYAP5gKmwXOegiCGFR/mW4ITiyfSsDmrcaeQ=="
-    },
-    "node_modules/@vocabulary/wgs": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/wgs/-/wgs-1.0.2.tgz",
-      "integrity": "sha512-ud/V5vaZckUvMqxUl1DND+dxueRMe4BEN3mdSv4BkDKyh6nrpGmOSKh9SoDNK2EctLsycCu6Up5fFz8MzDX3CA=="
-    },
-    "node_modules/@vocabulary/xhv": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/xhv/-/xhv-1.0.2.tgz",
-      "integrity": "sha512-I7zeLiO2TmJe0TnRmRRl2wW94+NILt8972muqJZoO6BsmUjWVf4j1yA9wgpXFldEh8L6GIW5BHfrHus3nfjvaw=="
-    },
-    "node_modules/@vocabulary/xkos": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/xkos/-/xkos-1.0.2.tgz",
-      "integrity": "sha512-3sCU2D9PiIkI9DDoyF6v6YWaYslbnYinOdR2B+iC4pkP3qMh/4N4mt35gHrxYIKC79vKUFxikbA4zEvbe5vEzQ=="
-    },
-    "node_modules/@vocabulary/xsd": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@vocabulary/xsd/-/xsd-1.0.2.tgz",
-      "integrity": "sha512-4SXpV4bS0fN5CDAXqUb+9/Rp+UyDPxEIPst8/ssh94s8Vssma3Foh6IRCRMXJqiWgizhLUAV5dDlbkAbxQck2Q=="
-    },
     "node_modules/@zazuko/env": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@zazuko/env/-/env-1.8.0.tgz",
-      "integrity": "sha512-saeT37xX0GI336dRfJXZYt5YwmCa0tgr9k49YYAUy6vYSm4DMrNWPLTkc7igQS8Rg+iiWwqAzMgpgIT1fFZoYw==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@zazuko/env/-/env-1.9.0.tgz",
+      "integrity": "sha512-2aZeNY3R7f0enBy5FY+um8rRuBsYkTxOWtAp7uKt0nw9hbF0CVsw0G1BRbrUYnZ2oWZk4STTJGZZyUQytxjZ2w==",
       "dependencies": {
         "@rdfjs/dataset": "^2.0.1",
         "@rdfjs/environment": "^0.1.2",
         "@rdfjs/traverser": "^0.1.2",
         "@tpluscode/rdf-ns-builders": "^4.1.0",
         "clownface": "^2.0.1",
+        "get-stream": "^8.0.1",
         "rdf-dataset-ext": "^1.1.0"
       },
       "peerDependencies": {
@@ -1068,42 +570,6 @@
         "@types/rdfjs__environment": "^0.1.7",
         "@types/rdfjs__formats-common": "^3.1.0",
         "@types/rdfjs__traverser": "^0.1.3"
-      }
-    },
-    "node_modules/@zazuko/env/node_modules/@rdfjs/data-model": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
-      "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw==",
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      }
-    },
-    "node_modules/@zazuko/env/node_modules/@rdfjs/namespace": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-2.0.0.tgz",
-      "integrity": "sha512-cBBvNrlSOah4z7u2vS74Lxng/ivELy6tNPjx+G/Ag14up8z5xmX8njn+U/mJ+nlcXO7nDGK4rgaAq7jtl9S3CQ==",
-      "dependencies": {
-        "@rdfjs/data-model": "^2.0.0"
-      }
-    },
-    "node_modules/@zazuko/env/node_modules/@tpluscode/rdf-ns-builders": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-4.2.0.tgz",
-      "integrity": "sha512-vSl+/38M3GKUV2mJ5HXfCxLUkoI3baRrBgLZnCKQPQUsptxzQGRxxIKFVHIIC3Dv+VA6V21/XLPl5Hik+nyRQQ==",
-      "dependencies": {
-        "@rdfjs/data-model": "^2",
-        "@rdfjs/namespace": "^2",
-        "@rdfjs/types": "*",
-        "@types/rdfjs__namespace": "^2.0.2",
-        "@zazuko/prefixes": "^2.0.1"
-      }
-    },
-    "node_modules/@zazuko/env/node_modules/clownface": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/clownface/-/clownface-2.0.1.tgz",
-      "integrity": "sha512-8RVfn/LZEl7BTDhIEIamz13Bhm5YahA1qiJigMb0HYGaiKnsVV0PpLBz0kzqyAI0+IzOlYbCLMFOAc1dkQfwgQ==",
-      "dependencies": {
-        "@rdfjs/environment": "^0.1.2"
       }
     },
     "node_modules/@zazuko/node-fetch": {
@@ -1121,225 +587,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@zazuko/prefixes/-/prefixes-2.1.0.tgz",
       "integrity": "sha512-dm0/YBNzuwJUm8cXoF3Dn9DfQetnRDaOJ8NdlgLY645OaUddCzUAAYcanm+xZmEo1SWX+/Tp3jbScwCaN2b/aQ=="
-    },
-    "node_modules/@zazuko/vocabularies": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@zazuko/vocabularies/-/vocabularies-2.0.3.tgz",
-      "integrity": "sha512-GMxPSyqqfGe2MWAFN5FGyVNIn/N5hipQCZHJUQaIp5sNJz9R5Q5QzQm2Pg4Uc3YYGnxo8YTersQeA1QvJVlbOQ==",
-      "dependencies": {
-        "@rdfjs/parser-n3": "^2.0.1",
-        "@vocabulary/acl": "^1.0.0",
-        "@vocabulary/as": "^1.0.0",
-        "@vocabulary/bibo": "^1.0.0",
-        "@vocabulary/cc": "^1.0.0",
-        "@vocabulary/cert": "^1.0.0",
-        "@vocabulary/cnt": "^1.0.0",
-        "@vocabulary/constant": "^1.0.0",
-        "@vocabulary/crm": "^1.0.0",
-        "@vocabulary/csvw": "^1.0.0",
-        "@vocabulary/ctag": "^1.0.0",
-        "@vocabulary/dash": "^1.0.0",
-        "@vocabulary/dash-sparql": "^1.0.0",
-        "@vocabulary/dbo": "^1.0.0",
-        "@vocabulary/dc11": "^1.0.0",
-        "@vocabulary/dcam": "^1.0.0",
-        "@vocabulary/dcat": "^1.0.0",
-        "@vocabulary/dcmitype": "^1.0.0",
-        "@vocabulary/dcterms": "^1.0.0",
-        "@vocabulary/dig": "^1.0.0",
-        "@vocabulary/discipline": "^1.0.0",
-        "@vocabulary/doap": "^1.0.0",
-        "@vocabulary/dpv": "^1.0.0",
-        "@vocabulary/dqv": "^1.0.0",
-        "@vocabulary/dtype": "^1.0.0",
-        "@vocabulary/duv": "^1.0.0",
-        "@vocabulary/earl": "^2.0.0",
-        "@vocabulary/ebucore": "^1.0.0",
-        "@vocabulary/exif": "^1.0.0",
-        "@vocabulary/foaf": "^1.0.0",
-        "@vocabulary/frbr": "^1.0.0",
-        "@vocabulary/geo": "^1.0.0",
-        "@vocabulary/geof": "^1.0.0",
-        "@vocabulary/geor": "^1.0.0",
-        "@vocabulary/gml": "^1.0.0",
-        "@vocabulary/gn": "^1.0.0",
-        "@vocabulary/gr": "^1.0.0",
-        "@vocabulary/grddl": "^1.0.0",
-        "@vocabulary/gs1": "^1.1.0",
-        "@vocabulary/gtfs": "^1.0.0",
-        "@vocabulary/http": "^1.0.0",
-        "@vocabulary/hydra": "^1.0.0",
-        "@vocabulary/ical": "^1.0.0",
-        "@vocabulary/la": "^1.0.0",
-        "@vocabulary/ldp": "^1.0.0",
-        "@vocabulary/list": "^1.0.0",
-        "@vocabulary/locn": "^1.0.0",
-        "@vocabulary/log": "^1.0.0",
-        "@vocabulary/lvont": "^1.0.0",
-        "@vocabulary/m4i": "^1.0.0",
-        "@vocabulary/ma": "^1.0.0",
-        "@vocabulary/mads": "^1.0.0",
-        "@vocabulary/math": "^1.0.0",
-        "@vocabulary/oa": "^1.0.0",
-        "@vocabulary/og": "^1.0.0",
-        "@vocabulary/oidc": "^1.0.0",
-        "@vocabulary/org": "^1.0.0",
-        "@vocabulary/owl": "^1.0.0",
-        "@vocabulary/pim": "^1.0.0",
-        "@vocabulary/prefix": "^1.0.0",
-        "@vocabulary/prov": "^1.0.0",
-        "@vocabulary/qb": "^1.0.0",
-        "@vocabulary/qkdv": "^1.0.0",
-        "@vocabulary/quantitykind": "^1.0.0",
-        "@vocabulary/qudt": "^1.0.0",
-        "@vocabulary/rdau": "^1.0.0",
-        "@vocabulary/rdf": "^1.0.0",
-        "@vocabulary/rdfa": "^1.0.0",
-        "@vocabulary/rdfs": "^1.0.0",
-        "@vocabulary/rev": "^1.0.0",
-        "@vocabulary/rico": "^1.0.0",
-        "@vocabulary/rr": "^1.0.0",
-        "@vocabulary/rss": "^1.0.0",
-        "@vocabulary/schema": "^1.0.0",
-        "@vocabulary/sd": "^1.0.0",
-        "@vocabulary/sdmx": "^1.0.0",
-        "@vocabulary/sem": "^1.0.0",
-        "@vocabulary/set": "^1.0.0",
-        "@vocabulary/sf": "^1.0.0",
-        "@vocabulary/sh": "^1.1.0",
-        "@vocabulary/shex": "^1.0.0",
-        "@vocabulary/shsh": "^1.0.0",
-        "@vocabulary/sioc": "^1.0.0",
-        "@vocabulary/skos": "^1.0.0",
-        "@vocabulary/skosxl": "^1.0.0",
-        "@vocabulary/solid": "^1.0.0",
-        "@vocabulary/sosa": "^1.0.0",
-        "@vocabulary/sou": "^1.0.0",
-        "@vocabulary/ssn": "^1.0.0",
-        "@vocabulary/stat": "^1.0.0",
-        "@vocabulary/string": "^1.0.0",
-        "@vocabulary/test": "^1.0.0",
-        "@vocabulary/time": "^1.0.0",
-        "@vocabulary/unit": "^1.0.0",
-        "@vocabulary/vaem": "^1.0.0",
-        "@vocabulary/vann": "^1.0.0",
-        "@vocabulary/vcard": "^1.0.0",
-        "@vocabulary/void": "^1.0.0",
-        "@vocabulary/vs": "^1.0.0",
-        "@vocabulary/wdrs": "^1.0.0",
-        "@vocabulary/wgs": "^1.0.0",
-        "@vocabulary/xhv": "^1.0.0",
-        "@vocabulary/xkos": "^1.0.0",
-        "@vocabulary/xsd": "^1.0.0",
-        "@zazuko/env": "^1.3.0",
-        "@zazuko/prefixes": "^2.1.0",
-        "@zazuko/vocabulary-loader": "^1.0.0",
-        "commander": "^10.0.0",
-        "rdf-dataset-ext": "^1",
-        "readable-stream": "^4.3.0"
-      },
-      "bin": {
-        "rdf-vocab": "bin/vocab.js"
-      }
-    },
-    "node_modules/@zazuko/vocabularies/node_modules/@rdfjs/data-model": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
-      "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw==",
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      }
-    },
-    "node_modules/@zazuko/vocabularies/node_modules/@rdfjs/parser-n3": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/parser-n3/-/parser-n3-2.0.1.tgz",
-      "integrity": "sha512-D9ZHQwtuKG7aF3nGcOijXWkaR//lpck0UB3AL+4P7OELY1idjmVjQjhreQxY5ll8cbPp2slavPvFfUWYSDtEwA==",
-      "dependencies": {
-        "@rdfjs/data-model": "^2.0.1",
-        "@rdfjs/sink": "^2.0.0",
-        "duplex-to": "^2.0.0",
-        "n3": "^1.16.2",
-        "readable-stream": "^4.2.0"
-      }
-    },
-    "node_modules/@zazuko/vocabularies/node_modules/@rdfjs/sink": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-2.0.0.tgz",
-      "integrity": "sha512-EDM6BjdVZdTHa6L3XWnXCDDu7h2tD/UAczc8WSG+Aw3m9yYkUUHypExNhlkA67sNRORC9Q/9hyHkAZBOVNRI6A=="
-    },
-    "node_modules/@zazuko/vocabularies/node_modules/commander": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
-      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
-      "engines": {
-        "node": ">=14"
-      }
-    },
-    "node_modules/@zazuko/vocabularies/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@zazuko/vocabulary-loader": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@zazuko/vocabulary-loader/-/vocabulary-loader-1.0.1.tgz",
-      "integrity": "sha512-m2OqQA1714zmDCifnRXEYUz5o8bkJI0wXUXAyAFosMbbR6WzHO+1xNuusbagqgFKGd6lq0LNhT14roiLy5aQhg==",
-      "dependencies": {
-        "@rdfjs/parser-n3": "^2.0.1",
-        "@types/rdfjs__environment": "^0.1",
-        "@zazuko/env": "^1.6.1",
-        "rdf-dataset-ext": "^1.1.0"
-      }
-    },
-    "node_modules/@zazuko/vocabulary-loader/node_modules/@rdfjs/data-model": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
-      "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw==",
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      }
-    },
-    "node_modules/@zazuko/vocabulary-loader/node_modules/@rdfjs/parser-n3": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/parser-n3/-/parser-n3-2.0.1.tgz",
-      "integrity": "sha512-D9ZHQwtuKG7aF3nGcOijXWkaR//lpck0UB3AL+4P7OELY1idjmVjQjhreQxY5ll8cbPp2slavPvFfUWYSDtEwA==",
-      "dependencies": {
-        "@rdfjs/data-model": "^2.0.1",
-        "@rdfjs/sink": "^2.0.0",
-        "duplex-to": "^2.0.0",
-        "n3": "^1.16.2",
-        "readable-stream": "^4.2.0"
-      }
-    },
-    "node_modules/@zazuko/vocabulary-loader/node_modules/@rdfjs/sink": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-2.0.0.tgz",
-      "integrity": "sha512-EDM6BjdVZdTHa6L3XWnXCDDu7h2tD/UAczc8WSG+Aw3m9yYkUUHypExNhlkA67sNRORC9Q/9hyHkAZBOVNRI6A=="
-    },
-    "node_modules/@zazuko/vocabulary-loader/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -1687,6 +934,14 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/clownface": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/clownface/-/clownface-2.0.1.tgz",
+      "integrity": "sha512-8RVfn/LZEl7BTDhIEIamz13Bhm5YahA1qiJigMb0HYGaiKnsVV0PpLBz0kzqyAI0+IzOlYbCLMFOAc1dkQfwgQ==",
+      "dependencies": {
+        "@rdfjs/environment": "^0.1.2"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1882,11 +1137,6 @@
       "funding": {
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
-    },
-    "node_modules/duplex-to": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/duplex-to/-/duplex-to-2.0.0.tgz",
-      "integrity": "sha512-f2nMnk11mwDptEFBTv2mcWHpF4ENAbuQ63yTiSy/99rG4Exsxsf0GJhJYq/AHF2cdMYswSx23LPuoijBflpquQ=="
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -2721,14 +1971,11 @@
       }
     },
     "node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-8.0.1.tgz",
+      "integrity": "sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==",
       "engines": {
-        "node": ">=8"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -3575,21 +2822,6 @@
         "node": ">=12.0"
       }
     },
-    "node_modules/n3/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -3640,21 +2872,6 @@
         "node-fetch": "^3.2.10",
         "readable-stream": "^4.2.0",
         "stream-chunks": "^1.0.0"
-      }
-    },
-    "node_modules/nodeify-fetch/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/object-assign": {
@@ -4102,6 +3319,30 @@
         "readable-stream": "^3.5.0"
       }
     },
+    "node_modules/rdf-transform-triple-to-quad/node_modules/@rdfjs/data-model": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
+      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.1"
+      },
+      "bin": {
+        "rdfjs-data-model-test": "bin/test.js"
+      }
+    },
+    "node_modules/rdf-transform-triple-to-quad/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/rdfxml-streaming-parser": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.2.3.tgz",
@@ -4126,22 +3367,6 @@
       "dependencies": {
         "@types/node": "*",
         "safe-buffer": "~5.1.1"
-      }
-    },
-    "node_modules/rdfxml-streaming-parser/node_modules/readable-stream": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
-      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
-      "peer": true,
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/react-is": {
@@ -4186,6 +3411,29 @@
       }
     },
     "node_modules/readable-stream": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readable-to-readable": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/readable-to-readable/-/readable-to-readable-0.1.3.tgz",
+      "integrity": "sha512-G+0kz01xJM/uTuItKcqC73cifW8S6CZ7tp77NLN87lE5mrSU+GC8geoSAlfmp0NocmXckQ7W8s8ns73HYsIA3w==",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/readable-to-readable/node_modules/readable-stream": {
       "version": "3.6.2",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
@@ -4196,14 +3444,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/readable-to-readable": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/readable-to-readable/-/readable-to-readable-0.1.3.tgz",
-      "integrity": "sha512-G+0kz01xJM/uTuItKcqC73cifW8S6CZ7tp77NLN87lE5mrSU+GC8geoSAlfmp0NocmXckQ7W8s8ns73HYsIA3w==",
-      "dependencies": {
-        "readable-stream": "^3.6.0"
       }
     },
     "node_modules/reflect.getprototypeof": {
@@ -4389,6 +3629,19 @@
         "readable-stream": "^3.6.0"
       }
     },
+    "node_modules/separate-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/set-function-length": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
@@ -4476,12 +3729,37 @@
         "separate-stream": "^1.0.0"
       }
     },
+    "node_modules/sparql-http-client/node_modules/@rdfjs/data-model": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
+      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.1"
+      },
+      "bin": {
+        "rdfjs-data-model-test": "bin/test.js"
+      }
+    },
     "node_modules/sparql-http-client/node_modules/@rdfjs/to-ntriples": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-1.0.2.tgz",
       "integrity": "sha512-ngw5XAaGHjgGiwWWBPGlfdCclHftonmbje5lMys4G2j4NvfExraPIuRZgjSnd5lg4dnulRVUll8tRbgKO+7EDA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/sparql-http-client/node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/sparql-http-client/node_modules/nodeify-fetch": {
@@ -4494,6 +3772,19 @@
         "cross-fetch": "^3.0.4",
         "readable-error": "^1.0.0",
         "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/sparql-http-client/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/sprintf-js": {
@@ -4738,6 +4029,19 @@
       "dependencies": {
         "inherits": "^2.0.4",
         "readable-stream": "2 || 3"
+      }
+    },
+    "node_modules/through2/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/tr46": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,7 +1,7 @@
 {
   "name": "@zazuko/trifid-plugin-ckan",
   "version": "2.0.1",
-  "lockfileVersion": 2,
+  "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
@@ -9,12 +9,12 @@
       "version": "2.0.1",
       "license": "UNLICENSED",
       "dependencies": {
-        "@tpluscode/rdf-string": "^0.2.26",
-        "@zazuko/rdf-vocabularies": "2022.11.28",
-        "dotenv": "^16.0.3",
-        "rdf-ext": "^2.1.0",
-        "sparql-http-client": "^2.4.1",
-        "xmlbuilder2": "^3.0.2"
+        "@tpluscode/rdf-string": "^1.1.0",
+        "@zazuko/env": "^1.8.0",
+        "@zazuko/vocabularies": "^2.0.3",
+        "dotenv": "^16.3.1",
+        "sparql-http-client": "^2.4.2",
+        "xmlbuilder2": "^3.1.1"
       },
       "devDependencies": {
         "standard": "^17.1.0"
@@ -27,18 +27,6 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -130,35 +118,11 @@
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
       "dev": true
     },
-    "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "peer": true,
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "peer": true
-    },
-    "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "peer": true,
-      "dependencies": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
       "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "2.0.5",
         "run-parallel": "^1.1.9"
@@ -171,6 +135,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
       "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
       "engines": {
         "node": ">= 8"
       }
@@ -179,6 +144,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
       "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
       "dependencies": {
         "@nodelib/fs.scandir": "2.1.5",
         "fastq": "^1.6.0"
@@ -231,57 +197,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/@rdf-esm/data-model": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@rdf-esm/data-model/-/data-model-0.5.4.tgz",
-      "integrity": "sha512-EINrtebCO6aT9e8vLmkaFFs317sCRj9cdFlKexvZA+7bLwcKrmcQLwC+nnnyBurtypHzWlokbLvp1SZHQWiH3w==",
-      "dependencies": {
-        "@rdfjs/data-model": "^1.2"
-      },
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@rdf-esm/namespace": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@rdf-esm/namespace/-/namespace-0.5.5.tgz",
-      "integrity": "sha512-JF26H4Mx+N93qIOu3KMsjdUW6As+dhvq9wP2Q03fjiS4l1rG+gKwfKUop8CHtVETVeDcNsO3+Srrq0wiQgAPDw==",
-      "dependencies": {
-        "@rdf-esm/data-model": "^0.5.1",
-        "@rdfjs/namespace": "^1.1.0",
-        "@types/rdfjs__namespace": "*"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@rdf-esm/term-map": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@rdf-esm/term-map/-/term-map-0.5.1.tgz",
-      "integrity": "sha512-Yq/5hBFt90q/eru2i9NVBxAayaGI/oWTPH1+6VoFueiaKSVl4Pf4lMX98/Hg/si5Ql0gG4B4wqBbFItl4LDI0A==",
-      "dependencies": {
-        "@rdf-esm/to-ntriples": "^0.6.0",
-        "@rdfjs/term-map": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@rdf-esm/to-ntriples": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@rdf-esm/to-ntriples/-/to-ntriples-0.6.0.tgz",
-      "integrity": "sha512-984lPZhKmFuLuJ74Q8SqtwzDDS43V98QXjpvu6jmlXEF2xQHwItmQk0AZ9Cyf26f3EiTVfLn3JHGWwkB0AK8IQ==",
-      "deprecated": "Use @rdfjs/to-ntriples",
-      "dependencies": {
-        "@rdfjs/to-ntriples": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@rdfjs/data-model": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
@@ -302,90 +217,66 @@
       }
     },
     "node_modules/@rdfjs/environment": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/environment/-/environment-0.1.1.tgz",
-      "integrity": "sha512-dU3wXZQ0nwJq17XH5/IWsRj980KkMR+lXS2LAfhzfaAyaZ09cQsjV+o2AQ4hp7r4PNMVQIz+8NAFE66WkSWIQw==",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/environment/-/environment-0.1.2.tgz",
+      "integrity": "sha512-R4N73kaoaOt3XvgLy2Cb98bJUgMJv/wRsUPGDxeogbtalkENPmo3X5to/rKQEwOjnj+jw+ILzN2webUHb8pvEw==",
       "dependencies": {
-        "@rdfjs/data-model": "^1.3.2",
-        "@rdfjs/dataset": "^1.1.1",
-        "@rdfjs/fetch-lite": "^2.1.2",
-        "@rdfjs/namespace": "^1.1.0",
-        "@rdfjs/sink-map": "^1.0.1",
-        "@rdfjs/term-map": "^1.1.0",
-        "@rdfjs/term-set": "^1.1.0"
+        "@rdfjs/data-model": "^2.0.1",
+        "@rdfjs/dataset": "^2.0.1",
+        "@rdfjs/fetch-lite": "^3.2.1",
+        "@rdfjs/namespace": "^2.0.0",
+        "@rdfjs/sink-map": "^2.0.0",
+        "@rdfjs/term-map": "^2.0.0",
+        "@rdfjs/term-set": "^2.0.1"
       }
     },
-    "node_modules/@rdfjs/environment/node_modules/@rdfjs/dataset": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.1.tgz",
-      "integrity": "sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==",
-      "dependencies": {
-        "@rdfjs/data-model": "^1.2.0"
-      },
+    "node_modules/@rdfjs/environment/node_modules/@rdfjs/data-model": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
+      "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw==",
       "bin": {
-        "rdfjs-dataset-test": "bin/test.js"
+        "rdfjs-data-model-test": "bin/test.js"
       }
     },
-    "node_modules/@rdfjs/environment/node_modules/@rdfjs/fetch-lite": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/fetch-lite/-/fetch-lite-2.1.2.tgz",
-      "integrity": "sha512-M66ShQbQH94/XdavOuCWLu5TFbx4pHxNLolC7oUvmIZI03mQOYyapEinGaaUozpdQoY8iOrekree4OORdRKFCA==",
+    "node_modules/@rdfjs/environment/node_modules/@rdfjs/namespace": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-2.0.0.tgz",
+      "integrity": "sha512-cBBvNrlSOah4z7u2vS74Lxng/ivELy6tNPjx+G/Ag14up8z5xmX8njn+U/mJ+nlcXO7nDGK4rgaAq7jtl9S3CQ==",
       "dependencies": {
-        "isstream": "^0.1.2",
-        "nodeify-fetch": "^2.2.1",
-        "readable-stream": "^3.3.0"
+        "@rdfjs/data-model": "^2.0.0"
       }
     },
-    "node_modules/@rdfjs/environment/node_modules/@rdfjs/term-set": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/term-set/-/term-set-1.1.0.tgz",
-      "integrity": "sha512-QQ4yzVe1Rvae/GN9SnOhweHNpaxQtnAjeOVciP/yJ0Gfxtbphy2tM56ZsRLV04Qq5qMcSclZIe6irYyEzx/UwQ==",
+    "node_modules/@rdfjs/environment/node_modules/@rdfjs/term-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/term-map/-/term-map-2.0.0.tgz",
+      "integrity": "sha512-z0K8AgLsJGTrh+dGkXNl/oT9vBdMei4xq1MIeGN360oimA81Q+ruQUKFCbYNRRZS03tVHPBzqXUal/DezFGPEA==",
       "dependencies": {
         "@rdfjs/to-ntriples": "^2.0.0"
       }
     },
-    "node_modules/@rdfjs/environment/node_modules/nodeify-fetch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/nodeify-fetch/-/nodeify-fetch-2.2.2.tgz",
-      "integrity": "sha512-4b1Jysy9RGyya0wJpseTQyxUgSbx6kw9ocHTY0OFRXWlxa2Uy5PrSo/P/nwoUn59rBR9YKty2kd7g4LKXmsZVA==",
-      "dependencies": {
-        "@zazuko/node-fetch": "^2.6.6",
-        "concat-stream": "^1.6.0",
-        "cross-fetch": "^3.0.4",
-        "readable-error": "^1.0.0",
-        "readable-stream": "^3.5.0"
-      }
-    },
     "node_modules/@rdfjs/fetch-lite": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/fetch-lite/-/fetch-lite-3.1.0.tgz",
-      "integrity": "sha512-S/85k+qM5I3Zyv9jPYOPLIpZycRZ0eX3tRga7HiwkrHFANqu/jZ9HpKQ9u8iohcX70QDl5Jsng/UKFdplRDQ8g==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/fetch-lite/-/fetch-lite-3.2.1.tgz",
+      "integrity": "sha512-cnCuSkEpMGsSbkd3+bIKheCKTDE4iBSGG6l/Inp0qg4y5WMLtcffKtSUzWhq09cAajm0dWs+5W3EGPNBqF5A4w==",
       "dependencies": {
-        "isstream": "^0.1.2",
-        "nodeify-fetch": "^3.0.0",
-        "readable-stream": "^3.6.0"
+        "is-stream": "^3.0.0",
+        "nodeify-fetch": "^3.1.0",
+        "readable-stream": "^4.2.0"
       }
     },
-    "node_modules/@rdfjs/namespace": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-1.1.0.tgz",
-      "integrity": "sha512-utO5rtaOKxk8B90qzaQ0N+J5WrCI28DtfAY/zExCmXE7cOfC5uRI/oMKbLaVEPj2P7uArekt/T4IPATtj7Tjug==",
+    "node_modules/@rdfjs/fetch-lite/node_modules/readable-stream": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
       "dependencies": {
-        "@rdfjs/data-model": "^1.1.0"
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@rdfjs/normalize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/normalize/-/normalize-2.0.0.tgz",
-      "integrity": "sha512-jOSdIKz9r/oPI9nuWXMTYzFaCbrFQj9qEOPdqs1/7oAR1JTvqpS69HVZPkVqbH+WhL52PJbBXyA5QadoyNLgpQ==",
-      "dependencies": {
-        "rdf-canonize": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 14.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/@rdfjs/parser-n3": {
@@ -400,41 +291,6 @@
         "readable-to-readable": "^0.1.0"
       }
     },
-    "node_modules/@rdfjs/prefix-map": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/prefix-map/-/prefix-map-0.1.0.tgz",
-      "integrity": "sha512-F3B2EXysSX0wu7gE5puJONPJVxTQLGroDTMvR/9ZRsBYffNlHZmtT8H2fWi5UiPbVxXBiMElN+Y6MIuinYmKog==",
-      "dependencies": {
-        "readable-stream": "^3.6.0"
-      }
-    },
-    "node_modules/@rdfjs/score": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/score/-/score-0.1.1.tgz",
-      "integrity": "sha512-+t9Sf5nFUJTvH8X2Xy7H+egLKIyVCwlDzCGrWThSrSCmIENcC9n3+GkMMImnsmYDeSXaWi3awcI1f1TmA84FIQ==",
-      "dependencies": {
-        "@rdfjs/data-model": "^2.0.1",
-        "@rdfjs/term-map": "^2.0.0",
-        "@rdfjs/term-set": "^2.0.1",
-        "@rdfjs/to-ntriples": "^2.0.0"
-      }
-    },
-    "node_modules/@rdfjs/score/node_modules/@rdfjs/data-model": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
-      "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw==",
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      }
-    },
-    "node_modules/@rdfjs/score/node_modules/@rdfjs/term-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/term-map/-/term-map-2.0.0.tgz",
-      "integrity": "sha512-z0K8AgLsJGTrh+dGkXNl/oT9vBdMei4xq1MIeGN360oimA81Q+ruQUKFCbYNRRZS03tVHPBzqXUal/DezFGPEA==",
-      "dependencies": {
-        "@rdfjs/to-ntriples": "^2.0.0"
-      }
-    },
     "node_modules/@rdfjs/sink": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-1.0.3.tgz",
@@ -444,20 +300,9 @@
       }
     },
     "node_modules/@rdfjs/sink-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/sink-map/-/sink-map-1.0.1.tgz",
-      "integrity": "sha512-PRp5TjULHe2oRcupR80SClZ/l50wnSuX2Pl+TlkcRazt1w7AT86kLmQYFbDfjqGM7uDwSyD6evLJxXBDf5UuvQ==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@rdfjs/term-map": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/term-map/-/term-map-1.1.0.tgz",
-      "integrity": "sha512-utCLVQEZdEL664XoYuBQwMIk0Q5MD6qNPEt12DcmuAlQUS0b0kQ+WL50wyJP1BpWYjOJLokIVTUtphZWnj25BQ==",
-      "dependencies": {
-        "@rdfjs/to-ntriples": "^2.0.0"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/sink-map/-/sink-map-2.0.0.tgz",
+      "integrity": "sha512-5Ahs1Ky6fglsqewpo89K7CFxD4EvFvAHdI/E5HJTu0L4tCUlvnZsmyKem4iYPDWdwsKplmUdORonUz75qPgd1g=="
     },
     "node_modules/@rdfjs/term-set": {
       "version": "2.0.1",
@@ -473,9 +318,12 @@
       "integrity": "sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q=="
     },
     "node_modules/@rdfjs/traverser": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/traverser/-/traverser-0.1.0.tgz",
-      "integrity": "sha512-9vYPgEg0tgYuOuLTXoyr33NRMvWULs2KcqfEG2afBny6XPf6Rfj3o9ONokj0OZQhj5ZVY+t6yIY08Dz1dtphMg=="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/traverser/-/traverser-0.1.2.tgz",
+      "integrity": "sha512-EBB/p9LrTMzupZ6VlxtBXyL0bdXFY7e5lAp2tHNwxOoe3kcR6hOJFVWdPT7pdWaSotyXbTIEQxG4PkXMw/OY7w==",
+      "dependencies": {
+        "@rdfjs/to-ntriples": "^2.0.0"
+      }
     },
     "node_modules/@rdfjs/types": {
       "version": "1.1.0",
@@ -485,96 +333,36 @@
         "@types/node": "*"
       }
     },
-    "node_modules/@tpluscode/rdf-ns-builders": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-2.0.1.tgz",
-      "integrity": "sha512-P/pwfjhcj/JOZF3epheHiDd/f9tSkceydQBqBuqThpNX2NIg+4BSgwtG2YfKBa24mmGFfyzN6RVeFclhA8wZBw==",
+    "node_modules/@rubensworks/saxes": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@rubensworks/saxes/-/saxes-6.0.1.tgz",
+      "integrity": "sha512-UW4OTIsOtJ5KSXo2Tchi4lhZqu+tlHrOAs4nNti7CrtB53kAZl3/hyrTi6HkMihxdbDM6m2Zc3swc/ZewEe1xw==",
+      "peer": true,
       "dependencies": {
-        "@rdf-esm/data-model": "^0.5.4",
-        "@rdf-esm/namespace": "^0.5.1",
-        "@rdfjs/types": "*",
-        "commander": "^7.2.0",
-        "fs-extra": "^10.0.0"
+        "xmlchars": "^2.2.0"
       },
-      "bin": {
-        "rdf-ns-builders": "bin/index.js"
-      },
-      "peerDependencies": {
-        "@zazuko/rdf-vocabularies": "*",
-        "clownface": "^1",
-        "safe-identifier": "^0.4.2",
-        "ts-morph": ">=11",
-        "ts-node": ">= 8"
+      "engines": {
+        "node": ">=v12.22.12"
       }
     },
     "node_modules/@tpluscode/rdf-string": {
-      "version": "0.2.26",
-      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-string/-/rdf-string-0.2.26.tgz",
-      "integrity": "sha512-zfNGMmY8D9jVuJ9qHwNrIWMwhibIkO42/1KtCfo59m4vXYTfJrXcn1ny9pj5kuhbpSubRbJ69zmYxP4UrXVPQw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-string/-/rdf-string-1.1.0.tgz",
+      "integrity": "sha512-n9RUQmeGS4V7Pj+zx/baURoFEia9ajmvwk4nG6pslgOMT3zp+d79dA20IjlOgC9zyYeH5bmMirXmIVOjeke3rQ==",
       "dependencies": {
-        "@rdf-esm/data-model": "^0.5.3",
-        "@rdf-esm/term-map": "^0.5.0",
         "@rdfjs/types": "*",
-        "@tpluscode/rdf-ns-builders": "^2",
-        "@zazuko/rdf-vocabularies": "*"
+        "@zazuko/env": "^1.5.2",
+        "@zazuko/prefixes": ">=1"
       }
     },
-    "node_modules/@ts-morph/common": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.18.1.tgz",
-      "integrity": "sha512-RVE+zSRICWRsfrkAw5qCAK+4ZH9kwEFv5h0+/YeHTLieWP7F4wWq4JsKFuNWG+fYh/KF+8rAtgdj5zb2mm+DVA==",
+    "node_modules/@types/clownface": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/clownface/-/clownface-2.0.3.tgz",
+      "integrity": "sha512-QTgH8F01lV29LSNvM6KVVdZVWaDcQ47JEZeeKp3ksRpoE5fOayXnt+3Yp+kdU4H/cpSM1KmKY6UiXVjUqYXwRg==",
       "peer": true,
       "dependencies": {
-        "fast-glob": "^3.2.12",
-        "minimatch": "^5.1.0",
-        "mkdirp": "^1.0.4",
-        "path-browserify": "^1.0.1"
+        "rdf-js": "^4.0.2"
       }
-    },
-    "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "peer": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/@ts-morph/common/node_modules/minimatch": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-      "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "peer": true
-    },
-    "node_modules/@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "peer": true
-    },
-    "node_modules/@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "peer": true
-    },
-    "node_modules/@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "peer": true
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -582,17 +370,163 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/jsonld": {
+      "version": "1.5.11",
+      "resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.11.tgz",
+      "integrity": "sha512-/B5yjthc6MEJMR4+TUtaj5LgE3bByVSNIXvPcUxiecj5F7GZKQJS5oery5rbOni7T9QBpjDF0RufCcVVlCe4hw==",
+      "peer": true
+    },
     "node_modules/@types/node": {
-      "version": "18.11.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.14.tgz",
-      "integrity": "sha512-0KXV57tENYmmJMl+FekeW9V3O/rlcqGQQJ/hNh9r8pKIj304pskWuEd8fCyNT86g/TpO0gcOTiLzsHLEURFMIQ=="
+      "version": "20.8.7",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.7.tgz",
+      "integrity": "sha512-21TKHHh3eUHIi2MloeptJWALuCu5H7HQTdTrWIFReA8ad+aggoX+lRes3ex7/FtpC+sVUpFMQ+QTfYr74mruiQ==",
+      "dependencies": {
+        "undici-types": "~5.25.1"
+      }
+    },
+    "node_modules/@types/rdf-dataset-ext": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@types/rdf-dataset-ext/-/rdf-dataset-ext-1.0.6.tgz",
+      "integrity": "sha512-gSKGOXk4z4AQcK+dnb4SUbtXC1sLbYraOueqJ2luHvA//sSC4IfeyjVH9/rXi3tnfyEtNA037WSR8Og4ROfAlA==",
+      "peer": true,
+      "dependencies": {
+        "@types/readable-stream": "*",
+        "rdf-js": "^4.0.2"
+      }
+    },
+    "node_modules/@types/rdfjs__data-model": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__data-model/-/rdfjs__data-model-2.0.6.tgz",
+      "integrity": "sha512-Xcz25z9AapM1YZ/RWM9hbSTGKC6l8CkYTaE3ZXObCxa1y5j++jhvQUfECjgA/0ikSMpD6dRSLMG0m5PYN+kfNQ==",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.1"
+      }
+    },
+    "node_modules/@types/rdfjs__dataset": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__dataset/-/rdfjs__dataset-2.0.6.tgz",
+      "integrity": "sha512-dkMgQMDb1V/uiNYt/uG+/56xMqEHZyBdInod/oTpUrb9xJ2Q2vHuQKQNphCYHEMm9+ELtZAePKDX1ZeB0/vWrg==",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__environment": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__environment/-/rdfjs__environment-0.1.9.tgz",
+      "integrity": "sha512-u7NUsgI2r0X06JXY8lMqcvEpgjVv1eL8lh//CGRsN6ovgA5RKYiTjedU80No21vPU/LEQ3wB8fJ5diMPy+IDDw==",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/node": "*",
+        "@types/rdfjs__data-model": "*",
+        "@types/rdfjs__dataset": "*",
+        "@types/rdfjs__namespace": "*",
+        "@types/rdfjs__sink-map": "*",
+        "@types/rdfjs__term-map": "*",
+        "@types/rdfjs__term-set": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__formats-common": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__formats-common/-/rdfjs__formats-common-3.1.3.tgz",
+      "integrity": "sha512-l2/d2u4TCTEPKx/9bLL0XonRRsmDBBs+RKohpKYQfyMl3D9SMSAcW3b9sJYuSSuEvnZM3e+Dn7l/8Zu1QV3AoQ==",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "@types/rdfjs__parser-jsonld": "*",
+        "@types/rdfjs__parser-n3": "*",
+        "@types/rdfjs__serializer-jsonld": "*",
+        "@types/rdfjs__serializer-ntriples": "*",
+        "@types/rdfjs__sink-map": "*",
+        "rdf-js": "^4.0.2",
+        "rdfxml-streaming-parser": ">=2"
+      }
     },
     "node_modules/@types/rdfjs__namespace": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-2.0.0.tgz",
-      "integrity": "sha512-bpVmmBrwg4plwfSNtwbwIYtZEpGFPWHTlfa1iftSY03+V+2wq+pfZxYkZwrhZwyh/Dxy5usIrVt04Rvigc4uXg==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-2.0.8.tgz",
+      "integrity": "sha512-py5L7+crlnuhd86DSxkw8jDAIHLf5YNfSXiLM5fe0aleleoP9X/L15Zrbz9k2Yr3ODY+lhboOLVGyyhfH43/Sw==",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__parser-jsonld": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__parser-jsonld/-/rdfjs__parser-jsonld-2.1.4.tgz",
+      "integrity": "sha512-McJLtE7LnZGfplcsnpVqvKRg7YGNMZCFF/hKV8kwrBcRrizgPvuzMza3pMXfqMncO7+aKHkT3IvVn+WQFOadRQ==",
+      "peer": true,
+      "dependencies": {
+        "@types/jsonld": "*",
+        "rdf-js": "^4.0.2"
+      }
+    },
+    "node_modules/@types/rdfjs__parser-n3": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__parser-n3/-/rdfjs__parser-n3-2.0.4.tgz",
+      "integrity": "sha512-zPibW5DTIYzM6kfQM3XeCASzGfQK+VIMJ0JYHVAwE6K04ILNQGGx1Ng3DF0r3nE/7Vhm44OtnCLsRo8wwsY+PA==",
+      "peer": true,
       "dependencies": {
         "rdf-js": "^4.0.2"
+      }
+    },
+    "node_modules/@types/rdfjs__serializer-jsonld": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-jsonld/-/rdfjs__serializer-jsonld-2.0.3.tgz",
+      "integrity": "sha512-KUKIlvNrEJYVfD7yRiywg1sPYyvBruVvvSHeFqQOUijPZ+Ox54lGnTPariy7jg3V/cTBEx4s8Sro8LCjV+i2Rg==",
+      "peer": true,
+      "dependencies": {
+        "rdf-js": "^4.0.2"
+      }
+    },
+    "node_modules/@types/rdfjs__serializer-ntriples": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-ntriples/-/rdfjs__serializer-ntriples-2.0.4.tgz",
+      "integrity": "sha512-wLMAhE0eB3FmaHHShsFWyIl9ZGVJWVmSHjSHTmMmvtswg5BxNs2Sx0ElejMiay8OsXhaGwV96RS1mx8uTLc8gw==",
+      "peer": true,
+      "dependencies": {
+        "rdf-js": "^4.0.2"
+      }
+    },
+    "node_modules/@types/rdfjs__sink-map": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__sink-map/-/rdfjs__sink-map-2.0.4.tgz",
+      "integrity": "sha512-B0y6Hu02VvceUW7dkRLW6+acCXBQPt+yIha234ogHOe9FnDLz2U9SDZwvh+9YECbqmEEY/NA2d5y8vNtAhtt7w==",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__term-map": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__term-map/-/rdfjs__term-map-2.0.8.tgz",
+      "integrity": "sha512-Rk2G68b26VBZi7ecFHd/Q0ot1FT7cu7Ae6Po+4ycWRk/r4RqawsQIRpixetnl55Y66kUzwtUfddsfOWZ3mEMXg==",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__term-set": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__term-set/-/rdfjs__term-set-2.0.7.tgz",
+      "integrity": "sha512-qPADoUsOv5CgLXRtEPuH+Yjbtk2IVCw44PRKYebUmSCvsaXXmY0cQz7SeKBGVO0F+OQ3CuA263xVur/QyWDgSA==",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__traverser": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__traverser/-/rdfjs__traverser-0.1.4.tgz",
+      "integrity": "sha512-bjIl9UwA931xm8hWJWrUpodO9UCii6ypVJpULi7befJpaeOyhEkVuZVOlci+oLPX828jzcd/8E4HxSwHZIXuNA==",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.4.tgz",
+      "integrity": "sha512-NSAiePj3Iq3kBArfpUWRNX/mRw8DibYD6YhNCIJDfUP/iIOQYsNJgtHyjpbuZlcbL7TxILS8qYjY/nXXvtcFQg==",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -600,6 +534,577 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
+    },
+    "node_modules/@vocabulary/acl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vocabulary/acl/-/acl-1.0.1.tgz",
+      "integrity": "sha512-zGf4PngXLP6KEnD3iDlbxqzcwatdVNhxgyBbC5M+HwmiOtdYG3i2MvEY4HnSebJOaAVaGzeluSs2eoc76+wPUg=="
+    },
+    "node_modules/@vocabulary/as": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/as/-/as-1.0.2.tgz",
+      "integrity": "sha512-L4vSUdnTeAvCrTvFrwrNWom0swdROmdiXeh4i6nbNx9LANA/br4CwHAyBHfYfgg88x7AVaJRX7fphEcVM2093Q=="
+    },
+    "node_modules/@vocabulary/bibo": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/bibo/-/bibo-1.0.2.tgz",
+      "integrity": "sha512-yAp8vQvQ3CwvBiH5G+XodRdV4YDsg9u0u4rJoxhqGk3q0hR6i3yLiLgdCUb77LLHicXD+HUC9FNfJ29OR8KPtA=="
+    },
+    "node_modules/@vocabulary/cc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/cc/-/cc-1.0.2.tgz",
+      "integrity": "sha512-4Alfe9crKv1pBymw/iqHLZa88wVPP9xYe0hhYUYY+AIKRWU+kfA/nwcvYhIU1JvZxPYmeH8GLSu7Oby0Rw3p4A=="
+    },
+    "node_modules/@vocabulary/cert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vocabulary/cert/-/cert-1.0.1.tgz",
+      "integrity": "sha512-PWjuMx/HRWubaK0we66AJ3PwXDz/9w3TmVidZePdFM50g2WE7L7OZOGskqFrLzxgUPl1F78Bc7vl5f/LRgVCMw=="
+    },
+    "node_modules/@vocabulary/cnt": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/cnt/-/cnt-1.0.2.tgz",
+      "integrity": "sha512-/UCZjhTi8mT2RWivwPpY4/4Y47PvqibmCiGOOh7K6/xX8d6su61oL6W/hwLf1pCNaiCIKYT5hVUdL5+rGRlf5g=="
+    },
+    "node_modules/@vocabulary/constant": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/constant/-/constant-1.0.2.tgz",
+      "integrity": "sha512-gE9SbdTA4lqWfzkHUu+Kof+bINYup7EsMvsDTIKb27LZg44EaKUy1ckVMArjx5UOwjrTw3u1O0piyAu7FNC+aQ=="
+    },
+    "node_modules/@vocabulary/crm": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/crm/-/crm-1.0.2.tgz",
+      "integrity": "sha512-9pB6HfHm0UyK5WGVjcppsBXCwOwhWF2PVJ+0pUzRuZ+IRcAKpKsfRZX3bdA/lMgn51wYFsb4JJIxB77csG/hyg=="
+    },
+    "node_modules/@vocabulary/csvw": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/csvw/-/csvw-1.0.2.tgz",
+      "integrity": "sha512-Gb3TNVsLL7l5og9/Kh0tLC4WxIRBsNJzy4abUn9k4LsZh+m2lO6fzA37lachWNX/8J0Njo9edZFQRuCu3SXVnQ=="
+    },
+    "node_modules/@vocabulary/ctag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/ctag/-/ctag-1.0.2.tgz",
+      "integrity": "sha512-487Y2p7tyfC9vYkZPhSgy099Qsl6na9SRIGaEQ/ml4zQhw6WTbPmuEcisMcBmfkqlPb9fn6GhQXCeVwdHAitvA=="
+    },
+    "node_modules/@vocabulary/dash": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/dash/-/dash-1.0.2.tgz",
+      "integrity": "sha512-XAnAuhdj7FxaK+c/hlSV17lh0mcTbiD9qMfUwCt/Japr/pcer0fAKPoLEhFjPLQLfDAv2Ud63DO7NC2JKZm2tA=="
+    },
+    "node_modules/@vocabulary/dash-sparql": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/dash-sparql/-/dash-sparql-1.0.2.tgz",
+      "integrity": "sha512-ZIp/D8SEfjHNYY0en4ijvwawoWJLrMA2w0hUL3Okdp/PKQmEQXAN4SPl9oz+N0Aaj5RGhD9nPA2iEhmGuXqczg=="
+    },
+    "node_modules/@vocabulary/dbo": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/dbo/-/dbo-1.0.2.tgz",
+      "integrity": "sha512-y/NU1O7KVUJPXRIKQ3q9N9K57dyPacO25aR4pxQptY4WXFJqMWGjVxRKEAqipZw7wGm1il0cFv45dBi2KMCpgg=="
+    },
+    "node_modules/@vocabulary/dc11": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/dc11/-/dc11-1.0.2.tgz",
+      "integrity": "sha512-w0JA2B3GxwnsLn/4z5WeuZuMk2DCi3M9MNpwa6A8RMbysvkiJHzSdIxohturV4+T5peBzLMEnqFbJFsqn3byJA=="
+    },
+    "node_modules/@vocabulary/dcam": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/dcam/-/dcam-1.0.2.tgz",
+      "integrity": "sha512-c6Q51eu+y2znnlLOs/NQNEOD1FPA3E6b+zCpFpQ4Ouqo4J+fl50LJZF+UTSOPvecaEDh5CFCfICjv98nh9jQ1g=="
+    },
+    "node_modules/@vocabulary/dcat": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/dcat/-/dcat-1.0.2.tgz",
+      "integrity": "sha512-h496KzF/N4FyLd2cEQLZXZ4unbSyEBb5ETnPkRtWwNlAdT1JCHCqEs2jPoS4Dp/CHV6JmHrbJYLU/8SwfmvsTg=="
+    },
+    "node_modules/@vocabulary/dcmitype": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/dcmitype/-/dcmitype-1.0.2.tgz",
+      "integrity": "sha512-MNc9zPFz4mHhU535zQU4vT2ebQwNQ/RyOFe7s+BUcfw2RCAmLH1mK1YFI7so9ngXx8HAC0iDfMwSV0FpcFBrFg=="
+    },
+    "node_modules/@vocabulary/dcterms": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/dcterms/-/dcterms-1.0.2.tgz",
+      "integrity": "sha512-XFe5NLoejzrHoIbxegztg12ag2Bg+/fycBI4rfRVkDgueKJS2rBj+lYmwP0xkzy815wLqhw7Dox5HMhYUkWftw=="
+    },
+    "node_modules/@vocabulary/dig": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/dig/-/dig-1.0.2.tgz",
+      "integrity": "sha512-Y5DaEpxvKu0fKmGJpASSq3TSFucTCNOlmt/uffirtNVdjV2sYfOuZ+PwTHYbGFJNAqN9rpns1hdANA4MjggdrA=="
+    },
+    "node_modules/@vocabulary/discipline": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/discipline/-/discipline-1.0.2.tgz",
+      "integrity": "sha512-BIocTlodM33B+T5L03nf0OFdLSLkZQZWNtUFbnOojIAfC3o6sNUft7gpUw2FsbDXLEM9ANbi7hNeiweyj5V2JA=="
+    },
+    "node_modules/@vocabulary/doap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/doap/-/doap-1.0.2.tgz",
+      "integrity": "sha512-dMekFHGjzQItNtrTSifGKPS5sF2edk1GNMXgxxHFzYbACZaxD93V0wyOe3qgqDrBfI3Hhy25KwkIipJKemeq3A=="
+    },
+    "node_modules/@vocabulary/dpv": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/dpv/-/dpv-1.0.2.tgz",
+      "integrity": "sha512-gSv/k/S2X4F9ikSK2f5mMvEo0jXaA0/3cXDYsZ2roRLeDVDpvIixpk7/NPZNWKdHj+5TNsWWOaVyFlAvTrlElg=="
+    },
+    "node_modules/@vocabulary/dqv": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/dqv/-/dqv-1.0.2.tgz",
+      "integrity": "sha512-DgmiB+QGlVnrBMZIkEe9T4rsfERoRvkUDL0gk/dvmE+vlQH5ENINcAHuFH0MC5UnOVl7ctjWQjqxfszpif3ekQ=="
+    },
+    "node_modules/@vocabulary/dtype": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/dtype/-/dtype-1.0.2.tgz",
+      "integrity": "sha512-CYtvCDKSnWBPepHEy1ZA7GRS0uSP/t3i/pg0rL2WZz08QsCxMNFNi/orLkX76RORUyAg7gJqI6fuNxb7GiXrTQ=="
+    },
+    "node_modules/@vocabulary/duv": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/duv/-/duv-1.0.2.tgz",
+      "integrity": "sha512-deg+8G/zzUZdevOyH5a/flmT3jGalg3Peiuf14lUEOLhebjXWWHFY7cMMkyvVEfj07V4FC24TeTHtKsPfYLydw=="
+    },
+    "node_modules/@vocabulary/earl": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/earl/-/earl-2.0.2.tgz",
+      "integrity": "sha512-PecS1aPHtrE6iSTuZgXEc3J3KanIwfg7Qh9wbXXUcExSYZ+0OzzAOVQeWHfAnRo13bCPS3UlxOnDEAcZvz3cxw=="
+    },
+    "node_modules/@vocabulary/ebucore": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/ebucore/-/ebucore-1.0.2.tgz",
+      "integrity": "sha512-9q/BVbcI2J1J32aa6HJEP46g1i6JMzp71Dy0ds41jqmblmWYqNmk8gfgBJCp0ImllRcMniYhR+q6CghBz+Pp9w=="
+    },
+    "node_modules/@vocabulary/exif": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/exif/-/exif-1.0.2.tgz",
+      "integrity": "sha512-QgMynz33XmpdG7kw66Jb1CGaAjX8y2L6vJVRz8DJ2lr+wUvf6RYzjVok/MkS+ou9+VEqZ0zbYo84mShWvGm1jA=="
+    },
+    "node_modules/@vocabulary/foaf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/foaf/-/foaf-1.0.2.tgz",
+      "integrity": "sha512-zQcjNHeeG4j7Rkxu50wqWcm1hyeqk0ZTyoQ1sAbNbJrs7s0Afanqvqw4GxL6YwF1Vp38Zk86W5VxNYnEQI/PSA=="
+    },
+    "node_modules/@vocabulary/frbr": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/frbr/-/frbr-1.0.2.tgz",
+      "integrity": "sha512-Nu5njOEMPpZkWwMPCBLsr0UFqEHg6Sh3yVFUj+s1DJHU1SfQ4PLRA5lBSczYsoiQ/4mYHrbo8Jwrw1RmD1mrWQ=="
+    },
+    "node_modules/@vocabulary/geo": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/geo/-/geo-1.0.2.tgz",
+      "integrity": "sha512-rMGmbMzcbVlU8mNWDxJZ3Qk8PDeuhwHeCz34Jbrc59GKba9uz1eTWJx3M78oEdX8DF/bRGOKu/Gt+bP+Ly2xVA=="
+    },
+    "node_modules/@vocabulary/geof": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/geof/-/geof-1.0.2.tgz",
+      "integrity": "sha512-JvJPov4dKuil6Kp29XD5D2wP0ZQubijCcL14Ax570GIu1cK/SX2lJfR3T7RyS2bV/ojBKmabV+a8956g931MsA=="
+    },
+    "node_modules/@vocabulary/geor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/geor/-/geor-1.0.2.tgz",
+      "integrity": "sha512-YFb+XTW1uRsiOjhWw0u+JwtKIkfk9GHWx0QJXmG97+O8ed7gKVF82NDN4NkaL1h+8Wsc+KvCZFZVOv+JJ7N8ng=="
+    },
+    "node_modules/@vocabulary/gml": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/gml/-/gml-1.0.2.tgz",
+      "integrity": "sha512-3THxTSJ/GDUQGgH/OYCLNso7veSGrLevFOrHlG6cxL5GZWAlXnirGGnsTSOY6YIFUR2pveRDwxyiRAcUMnSkmA=="
+    },
+    "node_modules/@vocabulary/gn": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/gn/-/gn-1.0.2.tgz",
+      "integrity": "sha512-baRl+Ah18TGH6f3ufOY5DHZmTNGUOB996StJZNkRRPmec5uXFlm4jNEl9E0P1kFZXH/3SZf4ewuAe3wzedNGLg=="
+    },
+    "node_modules/@vocabulary/gr": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/gr/-/gr-1.0.2.tgz",
+      "integrity": "sha512-G2UgHg4QW/YB/9PEs2y6XB1l53t1UAzBgMJKmcnhkOM9jPPF9YEG5mgvK6OphC1D/o8oFnVK3hmmzJQj+TVnsQ=="
+    },
+    "node_modules/@vocabulary/grddl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/grddl/-/grddl-1.0.2.tgz",
+      "integrity": "sha512-PLdZ1VSWWklkU+fNJV3uSFXNFtrB4lLTLUMUO8Mb4OXyGUKXZunb/fbBOqBjynjTme8yZ/uLiU4rSgrA8ZKZdQ=="
+    },
+    "node_modules/@vocabulary/gs1": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/gs1/-/gs1-1.1.2.tgz",
+      "integrity": "sha512-tsjdfaShHx1jWz5hzobcODp7UGnsxLdUQug3iPVwQvibfXEdmOKTOpFpuwAVi2JzafMzN77qFH62nuG8N/BfKw=="
+    },
+    "node_modules/@vocabulary/gtfs": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/gtfs/-/gtfs-1.0.2.tgz",
+      "integrity": "sha512-xIFhsU/mNcNAubUgpC5uUitKMQ7BQIbdvl26RGHemHd4rElKtkzt5y8z0r2hnmvCDo72qFyK2XfU2ndb1m+gNg=="
+    },
+    "node_modules/@vocabulary/http": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/http/-/http-1.0.2.tgz",
+      "integrity": "sha512-NhyYxC+Th5QDJfU5J6W91Oy0DWubro1F90OI7GyY7Tp7kZbC6o39vsKFIoY8QoPtUY8mUghNGb0WGrh5rdWKQQ=="
+    },
+    "node_modules/@vocabulary/hydra": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/hydra/-/hydra-1.0.2.tgz",
+      "integrity": "sha512-RIzOjYCQZGch5wHxJB7Vn7y/ianidIKLTK3nAgJ0Gdr3YEX05NJx9sduxbH7duDQnNaNPtjzAQH3LJ+eM7pZ8w=="
+    },
+    "node_modules/@vocabulary/ical": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/ical/-/ical-1.0.2.tgz",
+      "integrity": "sha512-wx8fFRltWb+d1iQnifvPQEwixENqWx+a28/W5T3L52hX/8wy/Ft5HOEF6OhUweajSzMkelJbmJpU1xXM+gXCbA=="
+    },
+    "node_modules/@vocabulary/la": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/la/-/la-1.0.2.tgz",
+      "integrity": "sha512-jPScZ6/j12nntpr1QDuOZ0qL6EmpZsYMAg6EYF+s7I3jWm8tQQYEeW3vUDvd3kKWn9zkVV2u8iisZjXnribwgQ=="
+    },
+    "node_modules/@vocabulary/ldp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/ldp/-/ldp-1.0.2.tgz",
+      "integrity": "sha512-DVgLR738toEFUPC6RKp4XJcn+U/PvHQaAXnRUJVRkofPa+xNrtmGtieWJjEU1RLGAiKWtF9tQkahbXnoHjDErQ=="
+    },
+    "node_modules/@vocabulary/list": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/list/-/list-1.0.2.tgz",
+      "integrity": "sha512-jpGcXTmfwRbTg+sq98k2CiPz5hT/qwDwGTXleEVSz84j8Fan/ArsuluTeg4NxHtxBmCJVVGdk2HVnqN2SEzjxQ=="
+    },
+    "node_modules/@vocabulary/locn": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/locn/-/locn-1.0.2.tgz",
+      "integrity": "sha512-cXMTt+pIj4F8LOulx2trp9NuJUUq2DFt0m3BV8D6NLEg7lcP2RA+keuk0xtx24Q3O5NeQkuYgJeFGkpq2u58yw=="
+    },
+    "node_modules/@vocabulary/log": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/log/-/log-1.0.2.tgz",
+      "integrity": "sha512-KTnrYtmzCyLej+gBsUlamm53TpOc+m/A82Vevw8tK0uqldP4CfVo1R0fUb2B64O4DsoE4jcOpS4PgJ1s7005EA=="
+    },
+    "node_modules/@vocabulary/lvont": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/lvont/-/lvont-1.0.2.tgz",
+      "integrity": "sha512-YMY3gVzWsH6TUwNTSaI/eNpYHzrzshbLpT2/NG5q9/YACOKSu20JFPP27/l3y+J2FOiyvqPzRUMt2bD//2izLA=="
+    },
+    "node_modules/@vocabulary/m4i": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@vocabulary/m4i/-/m4i-1.1.1.tgz",
+      "integrity": "sha512-P9jo9gkRrYgQZq7ZCzrzAQklkOucg+YUEfNGKNfFJvebx0TOtZUySQQyxJsNjXar8Bi3qTur8NSi7v6vBfhwAg=="
+    },
+    "node_modules/@vocabulary/ma": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/ma/-/ma-1.0.2.tgz",
+      "integrity": "sha512-mCuAMPb3v5Gpmzx8pakW+fA/yJP3oNW6u+fYGZP7xJDMoQGCsSFPRv6FkGjpyPSm9FbJ32tJSiM3JpQ7qg8Suw=="
+    },
+    "node_modules/@vocabulary/mads": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/mads/-/mads-1.0.2.tgz",
+      "integrity": "sha512-fi4xu7IlcTnnluzxGYr4T34E+Tl1COFozyJDBHhKLumt3RZuE56X4/g1gsrNTOlYldlFKgcaEOPPsfISfj2Q+g=="
+    },
+    "node_modules/@vocabulary/math": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/math/-/math-1.0.2.tgz",
+      "integrity": "sha512-o+WP8BoQDUMix7r34VJZru1oHY3vagjp9/aZEptnCNGt4kEmgX25W/Pv/QN0XUqS7fJitoZg2ay46FreQ5yU/g=="
+    },
+    "node_modules/@vocabulary/oa": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/oa/-/oa-1.0.2.tgz",
+      "integrity": "sha512-UlG2mdz+1wa8qlHjGMYrp2mkJzIldygrbA3+xZGArc6H1RlI4ZRb/WrhVldWLbFwHm+Za4CUa4T5Az9fh/BYew=="
+    },
+    "node_modules/@vocabulary/og": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/og/-/og-1.0.2.tgz",
+      "integrity": "sha512-xd9mF/d3CDhb7LQLtBSrYejwkq8fZg2X5gu+EUmMyHDMvhiHgPvtv2yhI85TZdwjxsX4tvmfqm9mhv/8l1OCMw=="
+    },
+    "node_modules/@vocabulary/oidc": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vocabulary/oidc/-/oidc-1.0.1.tgz",
+      "integrity": "sha512-rE+n+Q1WZhBDG3WiGg4RFJ0JnJBd4ySg4p5WL1qaHkkSeaY1VNzjLxJuH/LWaPw4CzT5ybNHJAYWxcUcqzaILA=="
+    },
+    "node_modules/@vocabulary/org": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/org/-/org-1.0.2.tgz",
+      "integrity": "sha512-ZyQsU5IPIHl1WebJ78KiB9d2z2a7jG2pTRS4+qZrKPjmns02CAhFCvOIo+445rNKVK0OJPQKeEKRFvzJKvbi6Q=="
+    },
+    "node_modules/@vocabulary/owl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/owl/-/owl-1.0.2.tgz",
+      "integrity": "sha512-bsnNM7Utan6fpwaAEOxXqo/vr76sv97Cn3WxQvfHM46bdnym2qXvXCtrpUZJ1rONlZaDtOzwdnEFvcMsEy1TdQ=="
+    },
+    "node_modules/@vocabulary/pim": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vocabulary/pim/-/pim-1.0.1.tgz",
+      "integrity": "sha512-kK2LxOKRpz62VRXEJJ1q2zbW7z0dyFAylLNzlU+hOyQJ+D84oLl0PpXviMUlsfCUfSSOrFmv4DmaCDM9z0qEdQ=="
+    },
+    "node_modules/@vocabulary/prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/prefix/-/prefix-1.0.2.tgz",
+      "integrity": "sha512-X+K9eop4T9LLEvKzVf2yYIVXH1WchbLu9vyP4SM7jNh4/IcPS5n0YcRw2SycsitKoylrsWyj0ur4kDMgtonbUA=="
+    },
+    "node_modules/@vocabulary/prov": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/prov/-/prov-1.0.2.tgz",
+      "integrity": "sha512-t3ZB7VyjBCCmbWdj+jt/SsE3ItJ1bVpZfi8LB7+ZFXwmNwbPM75GCQgtnIfVMFSl9BZNy9DiNOzmYo+KcbTOZg=="
+    },
+    "node_modules/@vocabulary/qb": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/qb/-/qb-1.0.2.tgz",
+      "integrity": "sha512-xcNUJxe/FrjIcAmKw3vkBYmgLqzMZFACrhSlNvoBJdCDm/G7vBczMigGqOHilffq1BIjAO3zQ7VAiZATtYoa+A=="
+    },
+    "node_modules/@vocabulary/qkdv": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/qkdv/-/qkdv-1.0.2.tgz",
+      "integrity": "sha512-TSkK74YnbaXzRkrTc98/hokHQ0/vBRLiMqeyAMUZAi0LJg7ZC1hjw36tijxL7Exg+b54jz3uMqBWGk6LFEjWaA=="
+    },
+    "node_modules/@vocabulary/quantitykind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/quantitykind/-/quantitykind-1.0.2.tgz",
+      "integrity": "sha512-Xv757ZwUbJaI6/EU0F+Vn+JoY/JWw+zb947pqKULCp9mr/XBL7iHoHj0fAmVJj3CYUTc5+9JlFoVdv755KWBLw=="
+    },
+    "node_modules/@vocabulary/qudt": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/qudt/-/qudt-1.0.2.tgz",
+      "integrity": "sha512-m56oA0tsi7B/C+FITiWYOMkq+GopbI8eddUr6N/QwRjc1LPYAM4RKpD54h+Wo8g0DfUv+UUe0yDDFsXWAEqzIw=="
+    },
+    "node_modules/@vocabulary/rdau": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/rdau/-/rdau-1.0.2.tgz",
+      "integrity": "sha512-ImTDNwnDV3dAfvJUP4LrNHEIelJ2lkeqde7bBP3bjRkYACyrsSnb7t21Y2xUTk4oC5jsjGj4x5T33ThYmROsHQ=="
+    },
+    "node_modules/@vocabulary/rdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/rdf/-/rdf-1.0.2.tgz",
+      "integrity": "sha512-lozo8HeTrncUA3m6zqQwymk875zKUmd5BaOW5M9VEf5sZteNV/wZ2hpytkBWQRbM1scqDq5M6uFVrMvwRLkdbw=="
+    },
+    "node_modules/@vocabulary/rdfa": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/rdfa/-/rdfa-1.0.2.tgz",
+      "integrity": "sha512-Igjb/h8efkKBUN+sgq1JK/9XwPDZLU/UpzWmtQX+6Am0iGPI2Dz1gVXqcEPzW/3Ph4Gcuk0vQPTa44b0EW0FPg=="
+    },
+    "node_modules/@vocabulary/rdfs": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/rdfs/-/rdfs-1.0.2.tgz",
+      "integrity": "sha512-nIwJ08+X33CyyReaE4iuA1iMyYCNI9u9OFTDf4FucNmEVvLjJdxJnMT5nz1gZuFuEiS6xsw4QS17xJLWUMokvg=="
+    },
+    "node_modules/@vocabulary/rev": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/rev/-/rev-1.0.2.tgz",
+      "integrity": "sha512-QL9tk91NyIQWMsOQRrOgR9x7NRTZ6F8YNA3UkUr7vMFFrB0CuWO1fk4U3fsPiPQCufoSa2dUYj5nPdqY6D6p8g=="
+    },
+    "node_modules/@vocabulary/rico": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/rico/-/rico-1.0.2.tgz",
+      "integrity": "sha512-mMwO00wAMJ1VPhfl6oLYxaJw5O8kND4oBL2UdkaJ4xDFggn8sJ1ausgOgjbyRbFCz+5cHY4kxWLUXZ0TzImYDw=="
+    },
+    "node_modules/@vocabulary/rr": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/rr/-/rr-1.0.2.tgz",
+      "integrity": "sha512-tXxRihBV3TtJxKzg5VXjeiMAJ23YdrijlvXMipqbwXCDxExVWe3t9jNZenw2yZ/bjDMionZHgnrEY+B6xXJl3A=="
+    },
+    "node_modules/@vocabulary/rss": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/rss/-/rss-1.0.2.tgz",
+      "integrity": "sha512-DNBUsXHO3nnMNhdj/GD4un+dCAiL07DgOys3l377IOFypf2LPCCfBjqx4deWLUXOtbnCtKV2WqRKbUxmd8trUA=="
+    },
+    "node_modules/@vocabulary/schema": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/schema/-/schema-1.0.2.tgz",
+      "integrity": "sha512-fXSYjivQnnCx29udegcoxKfj0+hSytYA66HdkK3QhmRWdwQ66bSnG0mTDAwLgvi9ewSVvNAeAUJ265Zq/8N9oQ=="
+    },
+    "node_modules/@vocabulary/sd": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/sd/-/sd-1.0.2.tgz",
+      "integrity": "sha512-LdBFdJAwJ4B+ofYtDdoyc51T3AmhcLHnHHndKHVDU9kr592Z7ohpAJbYvLbFXmeTllWix6iygkyGktQwi8dKxw=="
+    },
+    "node_modules/@vocabulary/sdmx": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/sdmx/-/sdmx-1.0.2.tgz",
+      "integrity": "sha512-bAwUgehx8h4soTjYXDfqKPuWOjktbicuuVFYgitYw2eW+ATn/BZHt2TFLbVq8JSU7KD0GcJeRde9rA3FN19giw=="
+    },
+    "node_modules/@vocabulary/sem": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/sem/-/sem-1.0.2.tgz",
+      "integrity": "sha512-4amt8BUcgzJpDv9lfQeFOnI90s0sdXvrVTfO62IECdr5sRHre5iNKSYgvEnX26CdfMspdJmoAHDTLRSJ2o71oA=="
+    },
+    "node_modules/@vocabulary/set": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/set/-/set-1.0.2.tgz",
+      "integrity": "sha512-8cWQmMyqGwGuvsUV0dNZj/+aGgBZK90KlM0UaTLojTFqnjxg04VnWVrTamtkNQKQXgdJAvbE2lSqq1SWlI/+8Q=="
+    },
+    "node_modules/@vocabulary/sf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/sf/-/sf-1.0.2.tgz",
+      "integrity": "sha512-5fyBBXskuNbTZf0xnPywYokXvYRM3+pOnCHo4h8IfMdpUoB8QJ4XfxTktlvyIYoPsf5aMiBfYudapkorHgpTOw=="
+    },
+    "node_modules/@vocabulary/sh": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/sh/-/sh-1.1.2.tgz",
+      "integrity": "sha512-1hXJe79ipXJbo/ywVGdefEcHPutedK2ilZv9G6op71wTibeUlCe1ik9OvnSeyH42RfLHqDs2vLvK3zH50RZS+w=="
+    },
+    "node_modules/@vocabulary/shex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/shex/-/shex-1.0.2.tgz",
+      "integrity": "sha512-n2pBiLYcXiEBurwZQVjYJrn0MOZaaB3RjzUwOIzJU6KpsFcR04Qwfs6DHItH16HwdHUsfbuu+LqsERyfrl5+Ig=="
+    },
+    "node_modules/@vocabulary/shsh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@vocabulary/shsh/-/shsh-1.0.0.tgz",
+      "integrity": "sha512-x8O9CpT3bTPU2BTeBm/tDpYxhkZ5Rfb1FVkJAQEA1MoHixUJcMcIEyBUJixcStx4sEVLos+29yKBW+rxqt+fRw=="
+    },
+    "node_modules/@vocabulary/sioc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/sioc/-/sioc-1.0.2.tgz",
+      "integrity": "sha512-jasDMFX6FE3NfLrzyQTIIZ7SaYSiw7foeSd9V3RLMNVdnGb+TdSA5tTc6IdO+shBL6y/bV89fqSrFhDBQkJ/1w=="
+    },
+    "node_modules/@vocabulary/skos": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/skos/-/skos-1.0.2.tgz",
+      "integrity": "sha512-qBP6d0lRUkReSbmn0Ca2h5aOPm+pbDXnTImbyn4uYadWzo+2N2D0i72bBe4G3CVSUtZ60DtqbzgzJLuGuimJlw=="
+    },
+    "node_modules/@vocabulary/skosxl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/skosxl/-/skosxl-1.0.2.tgz",
+      "integrity": "sha512-4WA1+f3uuwK0IlXvHAjhiPchSlmK04hO5rflNT8iIqYvKrk+st2RA6IeuWnT3Ra+6MXrr+3xChH6nI/z1D25mg=="
+    },
+    "node_modules/@vocabulary/solid": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vocabulary/solid/-/solid-1.0.1.tgz",
+      "integrity": "sha512-3X+VVGHbCPEiMrUqr1NL6AW/aITS6Gvu3PUlty46X6qMlpuQkWt6t5bzsmppJ2MMmzDWEijFLgAnh1hnzsJ6SQ=="
+    },
+    "node_modules/@vocabulary/sosa": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/sosa/-/sosa-1.0.2.tgz",
+      "integrity": "sha512-D9TkfzenKqwpc4JYd8Ww4ViU2sgkaI8YXBwOfqBGdPsZcVEYvyBgJayL/Pfa7yiBwgTD5brCZyiZnHz4K4WQXQ=="
+    },
+    "node_modules/@vocabulary/sou": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/sou/-/sou-1.0.2.tgz",
+      "integrity": "sha512-5/NyPD686hdrBdT2/amErDpgfXMsbqyXeMJythjNcC064Z4cr25JK6IdL73Q7ZoaocBf0t+mOoN7rIVyi6hTjg=="
+    },
+    "node_modules/@vocabulary/ssn": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/ssn/-/ssn-1.0.2.tgz",
+      "integrity": "sha512-ZCTWWMBULgdw164Yq4Eg2lrXPE/uKQBWIJ2pnd2CsTjYkc2+gDqEEM8PQmBfLuYpCMxIV7Pp+3gtXwUpAUz/ew=="
+    },
+    "node_modules/@vocabulary/stat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@vocabulary/stat/-/stat-1.0.1.tgz",
+      "integrity": "sha512-DK7Lst7Kovi5Jbo5pEDYtyRNYorac78iKPhhajsd9Yv1pBgIdYYwxxOUPovOMr3ia0NOoApOeyZC8bWli/vDKg=="
+    },
+    "node_modules/@vocabulary/string": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/string/-/string-1.0.2.tgz",
+      "integrity": "sha512-H1OalOpXwA7DgFqYcA+Dbd7vAmXZuhO1KjFgnBxxH4y+c4R1qG2HaHd40sz6ayPf8DpOoOXJ46ZBuFnTksKgiQ=="
+    },
+    "node_modules/@vocabulary/test": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/test/-/test-1.0.2.tgz",
+      "integrity": "sha512-iUme+7SK5xVj/ygYWpgdqhrrHtqzI0MhOOivLOBgmG/aWjd3lxNHmAbOdxJbU/kVL5N4w/NaDJKoq5mDStWlcw=="
+    },
+    "node_modules/@vocabulary/time": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/time/-/time-1.0.2.tgz",
+      "integrity": "sha512-d9BZoqXtgSmMPrDOhPuWUhQYVQdMKAct7Ge0StgbmcoI9XfAfS4HTc2vgtCe5WKaF+1KQNyhAo6yhynl0WO6mA=="
+    },
+    "node_modules/@vocabulary/unit": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/unit/-/unit-1.0.2.tgz",
+      "integrity": "sha512-cdec4YMNbl/8+X+ciOWXquBEZOcNoRP5zPlKX4rV34l3qAmChUJQUCc/JWYzdKQTfhFkJKisyqNq5MPaF0rnjA=="
+    },
+    "node_modules/@vocabulary/vaem": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/vaem/-/vaem-1.0.2.tgz",
+      "integrity": "sha512-ma0n5IlgbGnQdaXCUDd44Anat/Rp9rAU8V44uEUJakFBZS8Gr3GfpzmJVUtMvfFDes0yiibatJfyEHnzG211Hg=="
+    },
+    "node_modules/@vocabulary/vann": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/vann/-/vann-1.0.2.tgz",
+      "integrity": "sha512-/soY75MisKtnghp00zJLD7fLsEexp5iYgkspQHmCcA9z1NOwEGwwwckdCC3L0+5IGnaPH48EqkhJdzEQ9FVCoQ=="
+    },
+    "node_modules/@vocabulary/vcard": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/vcard/-/vcard-1.0.2.tgz",
+      "integrity": "sha512-tk1bScvz0GaDZdtvrdTa2r4b7d6l6EUY65giVMdHRUurns/sARx66J/g88SkaucqeQaZPnLrCGOEDbPsDNf6IA=="
+    },
+    "node_modules/@vocabulary/void": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/void/-/void-1.0.2.tgz",
+      "integrity": "sha512-a2mG69bQ8tPQv1xEHvsxZFdiubod/QwWTxzWZxNk8qFUeZr86/FVODxgc8jSLzqhbmA4qTmi02JmwD1gxO5Cug=="
+    },
+    "node_modules/@vocabulary/vs": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/vs/-/vs-1.0.2.tgz",
+      "integrity": "sha512-QDhCjZF4s1JB9lXBYCSieSe/hTuB1p3Mq7yni77W4EtENCRtIleMptk+onH4bnhQQYhLxmZG+l/a3a+krMLwlg=="
+    },
+    "node_modules/@vocabulary/wdrs": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/wdrs/-/wdrs-1.0.2.tgz",
+      "integrity": "sha512-rUdzYNJPy6GN/3KeD2tdiUCaTmY2hGlBcAdyn7WQD8aafIdIUhcYAP5gKmwXOegiCGFR/mW4ITiyfSsDmrcaeQ=="
+    },
+    "node_modules/@vocabulary/wgs": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/wgs/-/wgs-1.0.2.tgz",
+      "integrity": "sha512-ud/V5vaZckUvMqxUl1DND+dxueRMe4BEN3mdSv4BkDKyh6nrpGmOSKh9SoDNK2EctLsycCu6Up5fFz8MzDX3CA=="
+    },
+    "node_modules/@vocabulary/xhv": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/xhv/-/xhv-1.0.2.tgz",
+      "integrity": "sha512-I7zeLiO2TmJe0TnRmRRl2wW94+NILt8972muqJZoO6BsmUjWVf4j1yA9wgpXFldEh8L6GIW5BHfrHus3nfjvaw=="
+    },
+    "node_modules/@vocabulary/xkos": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/xkos/-/xkos-1.0.2.tgz",
+      "integrity": "sha512-3sCU2D9PiIkI9DDoyF6v6YWaYslbnYinOdR2B+iC4pkP3qMh/4N4mt35gHrxYIKC79vKUFxikbA4zEvbe5vEzQ=="
+    },
+    "node_modules/@vocabulary/xsd": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@vocabulary/xsd/-/xsd-1.0.2.tgz",
+      "integrity": "sha512-4SXpV4bS0fN5CDAXqUb+9/Rp+UyDPxEIPst8/ssh94s8Vssma3Foh6IRCRMXJqiWgizhLUAV5dDlbkAbxQck2Q=="
+    },
+    "node_modules/@zazuko/env": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@zazuko/env/-/env-1.8.0.tgz",
+      "integrity": "sha512-saeT37xX0GI336dRfJXZYt5YwmCa0tgr9k49YYAUy6vYSm4DMrNWPLTkc7igQS8Rg+iiWwqAzMgpgIT1fFZoYw==",
+      "dependencies": {
+        "@rdfjs/dataset": "^2.0.1",
+        "@rdfjs/environment": "^0.1.2",
+        "@rdfjs/traverser": "^0.1.2",
+        "@tpluscode/rdf-ns-builders": "^4.1.0",
+        "clownface": "^2.0.1",
+        "rdf-dataset-ext": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@types/clownface": "^2.0.0",
+        "@types/rdf-dataset-ext": "^1",
+        "@types/rdfjs__environment": "^0.1.7",
+        "@types/rdfjs__formats-common": "^3.1.0",
+        "@types/rdfjs__traverser": "^0.1.3"
+      }
+    },
+    "node_modules/@zazuko/env/node_modules/@rdfjs/data-model": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
+      "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw==",
+      "bin": {
+        "rdfjs-data-model-test": "bin/test.js"
+      }
+    },
+    "node_modules/@zazuko/env/node_modules/@rdfjs/namespace": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-2.0.0.tgz",
+      "integrity": "sha512-cBBvNrlSOah4z7u2vS74Lxng/ivELy6tNPjx+G/Ag14up8z5xmX8njn+U/mJ+nlcXO7nDGK4rgaAq7jtl9S3CQ==",
+      "dependencies": {
+        "@rdfjs/data-model": "^2.0.0"
+      }
+    },
+    "node_modules/@zazuko/env/node_modules/@tpluscode/rdf-ns-builders": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-4.2.0.tgz",
+      "integrity": "sha512-vSl+/38M3GKUV2mJ5HXfCxLUkoI3baRrBgLZnCKQPQUsptxzQGRxxIKFVHIIC3Dv+VA6V21/XLPl5Hik+nyRQQ==",
+      "dependencies": {
+        "@rdfjs/data-model": "^2",
+        "@rdfjs/namespace": "^2",
+        "@rdfjs/types": "*",
+        "@types/rdfjs__namespace": "^2.0.2",
+        "@zazuko/prefixes": "^2.0.1"
+      }
+    },
+    "node_modules/@zazuko/env/node_modules/clownface": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/clownface/-/clownface-2.0.1.tgz",
+      "integrity": "sha512-8RVfn/LZEl7BTDhIEIamz13Bhm5YahA1qiJigMb0HYGaiKnsVV0PpLBz0kzqyAI0+IzOlYbCLMFOAc1dkQfwgQ==",
+      "dependencies": {
+        "@rdfjs/environment": "^0.1.2"
+      }
     },
     "node_modules/@zazuko/node-fetch": {
       "version": "2.6.6",
@@ -612,59 +1117,228 @@
         "node": "4.x || >=6.0.0"
       }
     },
-    "node_modules/@zazuko/rdf-vocabularies": {
-      "version": "2022.11.28",
-      "resolved": "https://registry.npmjs.org/@zazuko/rdf-vocabularies/-/rdf-vocabularies-2022.11.28.tgz",
-      "integrity": "sha512-fg3GwDMI2ooS6VA2C23hFy5BrY5WO4lwjwa0/jYLYUpEHorTk430X0MvKQcfEgyz6U4NO8QDS8jz1CGvC4YLAw==",
+    "node_modules/@zazuko/prefixes": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@zazuko/prefixes/-/prefixes-2.1.0.tgz",
+      "integrity": "sha512-dm0/YBNzuwJUm8cXoF3Dn9DfQetnRDaOJ8NdlgLY645OaUddCzUAAYcanm+xZmEo1SWX+/Tp3jbScwCaN2b/aQ=="
+    },
+    "node_modules/@zazuko/vocabularies": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@zazuko/vocabularies/-/vocabularies-2.0.3.tgz",
+      "integrity": "sha512-GMxPSyqqfGe2MWAFN5FGyVNIn/N5hipQCZHJUQaIp5sNJz9R5Q5QzQm2Pg4Uc3YYGnxo8YTersQeA1QvJVlbOQ==",
       "dependencies": {
-        "@rdfjs/parser-n3": "^1.1.4",
-        "commander": "^5.0.0",
-        "pkg-dir": "^5.0.0",
-        "rdf-ext": "^1.3.5",
-        "readable-stream": "^3.6.0",
-        "string-to-stream": "^3.0.1"
+        "@rdfjs/parser-n3": "^2.0.1",
+        "@vocabulary/acl": "^1.0.0",
+        "@vocabulary/as": "^1.0.0",
+        "@vocabulary/bibo": "^1.0.0",
+        "@vocabulary/cc": "^1.0.0",
+        "@vocabulary/cert": "^1.0.0",
+        "@vocabulary/cnt": "^1.0.0",
+        "@vocabulary/constant": "^1.0.0",
+        "@vocabulary/crm": "^1.0.0",
+        "@vocabulary/csvw": "^1.0.0",
+        "@vocabulary/ctag": "^1.0.0",
+        "@vocabulary/dash": "^1.0.0",
+        "@vocabulary/dash-sparql": "^1.0.0",
+        "@vocabulary/dbo": "^1.0.0",
+        "@vocabulary/dc11": "^1.0.0",
+        "@vocabulary/dcam": "^1.0.0",
+        "@vocabulary/dcat": "^1.0.0",
+        "@vocabulary/dcmitype": "^1.0.0",
+        "@vocabulary/dcterms": "^1.0.0",
+        "@vocabulary/dig": "^1.0.0",
+        "@vocabulary/discipline": "^1.0.0",
+        "@vocabulary/doap": "^1.0.0",
+        "@vocabulary/dpv": "^1.0.0",
+        "@vocabulary/dqv": "^1.0.0",
+        "@vocabulary/dtype": "^1.0.0",
+        "@vocabulary/duv": "^1.0.0",
+        "@vocabulary/earl": "^2.0.0",
+        "@vocabulary/ebucore": "^1.0.0",
+        "@vocabulary/exif": "^1.0.0",
+        "@vocabulary/foaf": "^1.0.0",
+        "@vocabulary/frbr": "^1.0.0",
+        "@vocabulary/geo": "^1.0.0",
+        "@vocabulary/geof": "^1.0.0",
+        "@vocabulary/geor": "^1.0.0",
+        "@vocabulary/gml": "^1.0.0",
+        "@vocabulary/gn": "^1.0.0",
+        "@vocabulary/gr": "^1.0.0",
+        "@vocabulary/grddl": "^1.0.0",
+        "@vocabulary/gs1": "^1.1.0",
+        "@vocabulary/gtfs": "^1.0.0",
+        "@vocabulary/http": "^1.0.0",
+        "@vocabulary/hydra": "^1.0.0",
+        "@vocabulary/ical": "^1.0.0",
+        "@vocabulary/la": "^1.0.0",
+        "@vocabulary/ldp": "^1.0.0",
+        "@vocabulary/list": "^1.0.0",
+        "@vocabulary/locn": "^1.0.0",
+        "@vocabulary/log": "^1.0.0",
+        "@vocabulary/lvont": "^1.0.0",
+        "@vocabulary/m4i": "^1.0.0",
+        "@vocabulary/ma": "^1.0.0",
+        "@vocabulary/mads": "^1.0.0",
+        "@vocabulary/math": "^1.0.0",
+        "@vocabulary/oa": "^1.0.0",
+        "@vocabulary/og": "^1.0.0",
+        "@vocabulary/oidc": "^1.0.0",
+        "@vocabulary/org": "^1.0.0",
+        "@vocabulary/owl": "^1.0.0",
+        "@vocabulary/pim": "^1.0.0",
+        "@vocabulary/prefix": "^1.0.0",
+        "@vocabulary/prov": "^1.0.0",
+        "@vocabulary/qb": "^1.0.0",
+        "@vocabulary/qkdv": "^1.0.0",
+        "@vocabulary/quantitykind": "^1.0.0",
+        "@vocabulary/qudt": "^1.0.0",
+        "@vocabulary/rdau": "^1.0.0",
+        "@vocabulary/rdf": "^1.0.0",
+        "@vocabulary/rdfa": "^1.0.0",
+        "@vocabulary/rdfs": "^1.0.0",
+        "@vocabulary/rev": "^1.0.0",
+        "@vocabulary/rico": "^1.0.0",
+        "@vocabulary/rr": "^1.0.0",
+        "@vocabulary/rss": "^1.0.0",
+        "@vocabulary/schema": "^1.0.0",
+        "@vocabulary/sd": "^1.0.0",
+        "@vocabulary/sdmx": "^1.0.0",
+        "@vocabulary/sem": "^1.0.0",
+        "@vocabulary/set": "^1.0.0",
+        "@vocabulary/sf": "^1.0.0",
+        "@vocabulary/sh": "^1.1.0",
+        "@vocabulary/shex": "^1.0.0",
+        "@vocabulary/shsh": "^1.0.0",
+        "@vocabulary/sioc": "^1.0.0",
+        "@vocabulary/skos": "^1.0.0",
+        "@vocabulary/skosxl": "^1.0.0",
+        "@vocabulary/solid": "^1.0.0",
+        "@vocabulary/sosa": "^1.0.0",
+        "@vocabulary/sou": "^1.0.0",
+        "@vocabulary/ssn": "^1.0.0",
+        "@vocabulary/stat": "^1.0.0",
+        "@vocabulary/string": "^1.0.0",
+        "@vocabulary/test": "^1.0.0",
+        "@vocabulary/time": "^1.0.0",
+        "@vocabulary/unit": "^1.0.0",
+        "@vocabulary/vaem": "^1.0.0",
+        "@vocabulary/vann": "^1.0.0",
+        "@vocabulary/vcard": "^1.0.0",
+        "@vocabulary/void": "^1.0.0",
+        "@vocabulary/vs": "^1.0.0",
+        "@vocabulary/wdrs": "^1.0.0",
+        "@vocabulary/wgs": "^1.0.0",
+        "@vocabulary/xhv": "^1.0.0",
+        "@vocabulary/xkos": "^1.0.0",
+        "@vocabulary/xsd": "^1.0.0",
+        "@zazuko/env": "^1.3.0",
+        "@zazuko/prefixes": "^2.1.0",
+        "@zazuko/vocabulary-loader": "^1.0.0",
+        "commander": "^10.0.0",
+        "rdf-dataset-ext": "^1",
+        "readable-stream": "^4.3.0"
       },
       "bin": {
         "rdf-vocab": "bin/vocab.js"
       }
     },
-    "node_modules/@zazuko/rdf-vocabularies/node_modules/@rdfjs/dataset": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.1.tgz",
-      "integrity": "sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==",
-      "dependencies": {
-        "@rdfjs/data-model": "^1.2.0"
-      },
+    "node_modules/@zazuko/vocabularies/node_modules/@rdfjs/data-model": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
+      "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw==",
       "bin": {
-        "rdfjs-dataset-test": "bin/test.js"
+        "rdfjs-data-model-test": "bin/test.js"
       }
     },
-    "node_modules/@zazuko/rdf-vocabularies/node_modules/@rdfjs/to-ntriples": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-1.0.2.tgz",
-      "integrity": "sha512-ngw5XAaGHjgGiwWWBPGlfdCclHftonmbje5lMys4G2j4NvfExraPIuRZgjSnd5lg4dnulRVUll8tRbgKO+7EDA==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@zazuko/rdf-vocabularies/node_modules/commander": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/@zazuko/rdf-vocabularies/node_modules/rdf-ext": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/rdf-ext/-/rdf-ext-1.3.5.tgz",
-      "integrity": "sha512-LS/waItwp5aGY9Ay7y147HxWLIaSvw4r172S995aGwVkvg0KwUA0NY8w61p/LoFdQ4V6mzxQdVoRN6x/6OaK0w==",
+    "node_modules/@zazuko/vocabularies/node_modules/@rdfjs/parser-n3": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/parser-n3/-/parser-n3-2.0.1.tgz",
+      "integrity": "sha512-D9ZHQwtuKG7aF3nGcOijXWkaR//lpck0UB3AL+4P7OELY1idjmVjQjhreQxY5ll8cbPp2slavPvFfUWYSDtEwA==",
       "dependencies": {
-        "@rdfjs/data-model": "^1.3.3",
-        "@rdfjs/dataset": "^1.1.1",
-        "@rdfjs/to-ntriples": "^1.0.1",
-        "rdf-normalize": "^1.0.0",
-        "readable-stream": "^3.6.0"
+        "@rdfjs/data-model": "^2.0.1",
+        "@rdfjs/sink": "^2.0.0",
+        "duplex-to": "^2.0.0",
+        "n3": "^1.16.2",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@zazuko/vocabularies/node_modules/@rdfjs/sink": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-2.0.0.tgz",
+      "integrity": "sha512-EDM6BjdVZdTHa6L3XWnXCDDu7h2tD/UAczc8WSG+Aw3m9yYkUUHypExNhlkA67sNRORC9Q/9hyHkAZBOVNRI6A=="
+    },
+    "node_modules/@zazuko/vocabularies/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@zazuko/vocabularies/node_modules/readable-stream": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@zazuko/vocabulary-loader": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@zazuko/vocabulary-loader/-/vocabulary-loader-1.0.1.tgz",
+      "integrity": "sha512-m2OqQA1714zmDCifnRXEYUz5o8bkJI0wXUXAyAFosMbbR6WzHO+1xNuusbagqgFKGd6lq0LNhT14roiLy5aQhg==",
+      "dependencies": {
+        "@rdfjs/parser-n3": "^2.0.1",
+        "@types/rdfjs__environment": "^0.1",
+        "@zazuko/env": "^1.6.1",
+        "rdf-dataset-ext": "^1.1.0"
+      }
+    },
+    "node_modules/@zazuko/vocabulary-loader/node_modules/@rdfjs/data-model": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
+      "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw==",
+      "bin": {
+        "rdfjs-data-model-test": "bin/test.js"
+      }
+    },
+    "node_modules/@zazuko/vocabulary-loader/node_modules/@rdfjs/parser-n3": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/parser-n3/-/parser-n3-2.0.1.tgz",
+      "integrity": "sha512-D9ZHQwtuKG7aF3nGcOijXWkaR//lpck0UB3AL+4P7OELY1idjmVjQjhreQxY5ll8cbPp2slavPvFfUWYSDtEwA==",
+      "dependencies": {
+        "@rdfjs/data-model": "^2.0.1",
+        "@rdfjs/sink": "^2.0.0",
+        "duplex-to": "^2.0.0",
+        "n3": "^1.16.2",
+        "readable-stream": "^4.2.0"
+      }
+    },
+    "node_modules/@zazuko/vocabulary-loader/node_modules/@rdfjs/sink": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-2.0.0.tgz",
+      "integrity": "sha512-EDM6BjdVZdTHa6L3XWnXCDDu7h2tD/UAczc8WSG+Aw3m9yYkUUHypExNhlkA67sNRORC9Q/9hyHkAZBOVNRI6A=="
+    },
+    "node_modules/@zazuko/vocabulary-loader/node_modules/readable-stream": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -682,6 +1356,7 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -696,15 +1371,6 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/ajv": {
@@ -746,12 +1412,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "peer": true
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -847,16 +1507,16 @@
       }
     },
     "node_modules/array.prototype.tosorted": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
-      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.2.tgz",
+      "integrity": "sha512-HuQCHOlk1Weat5jzStICBCd83NxiIMwqDg/dHEsoefabn/hJRj5pVdWcPUSpRrwhwxZOsQassMpgN/xRYFBMIg==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
         "es-shim-unscopables": "^1.0.0",
-        "get-intrinsic": "^1.1.3"
+        "get-intrinsic": "^1.2.1"
       }
     },
     "node_modules/arraybuffer.prototype.slice": {
@@ -904,7 +1564,8 @@
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -933,18 +1594,6 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "peer": true,
-      "dependencies": {
-        "fill-range": "^7.0.1"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/buffer": {
@@ -1038,21 +1687,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/clownface": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/clownface/-/clownface-1.5.1.tgz",
-      "integrity": "sha512-Ko8N/UFsnhEGmPlyE1bUFhbRhVgDbxqlIjcqxtLysc4dWaY0A7iCdg3savhAxs7Lheb7FCygIyRh7ADYZWVIng==",
-      "dependencies": {
-        "@rdfjs/data-model": "^1.1.0",
-        "@rdfjs/namespace": "^1.0.0"
-      }
-    },
-    "node_modules/code-block-writer": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
-      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==",
-      "peer": true
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1070,14 +1704,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
-      "engines": {
-        "node": ">= 10"
-      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1099,10 +1725,15 @@
         "typedarray": "^0.0.6"
       }
     },
+    "node_modules/concat-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "node_modules/concat-stream/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -1112,11 +1743,6 @@
         "string_decoder": "~1.1.1",
         "util-deprecate": "~1.0.1"
       }
-    },
-    "node_modules/concat-stream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/concat-stream/node_modules/string_decoder": {
       "version": "1.1.1",
@@ -1131,24 +1757,18 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
-    "node_modules/create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "peer": true
-    },
     "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
       "dependencies": {
-        "node-fetch": "2.6.7"
+        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-fetch/node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -1179,9 +1799,9 @@
       }
     },
     "node_modules/data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
       "engines": {
         "node": ">= 12"
       }
@@ -1240,15 +1860,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
     "node_modules/doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -1262,12 +1873,20 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "version": "16.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
+      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
+    },
+    "node_modules/duplex-to": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/duplex-to/-/duplex-to-2.0.0.tgz",
+      "integrity": "sha512-f2nMnk11mwDptEFBTv2mcWHpF4ENAbuQ63yTiSy/99rG4Exsxsf0GJhJYq/AHF2cdMYswSx23LPuoijBflpquQ=="
     },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
@@ -1376,12 +1995,12 @@
       }
     },
     "node_modules/es-shim-unscopables": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.2.tgz",
+      "integrity": "sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==",
       "dev": true,
       "dependencies": {
-        "has": "^1.0.3"
+        "hasown": "^2.0.0"
       }
     },
     "node_modules/es-to-primitive": {
@@ -1757,12 +2376,12 @@
       }
     },
     "node_modules/eslint-plugin-react/node_modules/resolve": {
-      "version": "2.0.0-next.4",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
-      "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
+      "version": "2.0.0-next.5",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.5.tgz",
+      "integrity": "sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==",
       "dev": true,
       "dependencies": {
-        "is-core-module": "^2.9.0",
+        "is-core-module": "^2.13.0",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
       },
@@ -1921,34 +2540,6 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
-    "node_modules/fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
-      "peer": true,
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8.6.0"
-      }
-    },
-    "node_modules/fast-glob/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "peer": true,
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1962,9 +2553,10 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
-      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+      "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
       }
@@ -2003,22 +2595,11 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "peer": true,
-      "dependencies": {
-        "to-regex-range": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
@@ -2031,22 +2612,23 @@
       }
     },
     "node_modules/flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.1.tgz",
+      "integrity": "sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==",
       "dev": true,
       "dependencies": {
-        "flatted": "^3.1.0",
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
         "rimraf": "^3.0.2"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": ">=12.0.0"
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
+      "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
       "dev": true
     },
     "node_modules/for-each": {
@@ -2067,19 +2649,6 @@
       },
       "engines": {
         "node": ">=12.20.0"
-      }
-    },
-    "node_modules/fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/fs.realpath": {
@@ -2256,27 +2825,16 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
-    },
-    "node_modules/has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "dependencies": {
-        "function-bind": "^1.1.1"
-      },
-      "engines": {
-        "node": ">= 0.4.0"
-      }
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",
@@ -2297,12 +2855,12 @@
       }
     },
     "node_modules/has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+      "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
       "dev": true,
       "dependencies": {
-        "get-intrinsic": "^1.1.1"
+        "get-intrinsic": "^1.2.2"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -2547,6 +3105,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2582,6 +3141,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -2608,15 +3168,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "peer": true,
-      "engines": {
-        "node": ">=0.12.0"
       }
     },
     "node_modules/is-number-object": {
@@ -2678,6 +3229,17 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
+      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -2760,20 +3322,16 @@
       }
     },
     "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true
     },
     "node_modules/isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "node_modules/iterator.prototype": {
       "version": "1.1.2",
@@ -2806,6 +3364,12 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
     "node_modules/json-parse-better-errors": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
@@ -2836,17 +3400,6 @@
         "json5": "lib/cli.js"
       }
     },
-    "node_modules/jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dependencies": {
-        "universalify": "^2.0.0"
-      },
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
     "node_modules/jsonparse": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
@@ -2872,16 +3425,27 @@
       }
     },
     "node_modules/jsx-ast-utils": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
-      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
       "dev": true,
       "dependencies": {
-        "array-includes": "^3.1.5",
-        "object.assign": "^4.1.3"
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
       }
     },
     "node_modules/levn": {
@@ -2926,6 +3490,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
       "dependencies": {
         "p-locate": "^5.0.0"
       },
@@ -2971,34 +3536,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "peer": true
-    },
-    "node_modules/merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "peer": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "peer": true,
-      "dependencies": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      },
-      "engines": {
-        "node": ">=8.6"
-      }
-    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3012,24 +3549,12 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "peer": true,
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/ms": {
@@ -3039,9 +3564,9 @@
       "dev": true
     },
     "node_modules/n3": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.3.tgz",
-      "integrity": "sha512-9caLSZuMW1kdlPxEN4ka6E4E8a5QKoZ2emxpW+zHMofI+Bo92nJhN//wNub15S5T9I4c6saEqdGEu+YXJqMZVA==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.17.1.tgz",
+      "integrity": "sha512-HlanMWpvN2kcTrFuU3GPObyY7qrVQWy2Hp7l4GSXJlcQapjQMR7OM4kCr788pTQzNIpiHS3JRvyZ2YUcYJ82rA==",
       "dependencies": {
         "queue-microtask": "^1.1.2",
         "readable-stream": "^4.0.0"
@@ -3051,14 +3576,15 @@
       }
     },
     "node_modules/n3/node_modules/readable-stream": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
-      "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
-        "process": "^0.11.10"
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3089,9 +3615,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -3117,14 +3643,15 @@
       }
     },
     "node_modules/nodeify-fetch/node_modules/readable-stream": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
-      "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
       "dependencies": {
         "abort-controller": "^3.0.0",
         "buffer": "^6.0.3",
         "events": "^3.3.0",
-        "process": "^0.11.10"
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -3176,14 +3703,14 @@
       }
     },
     "node_modules/object.entries": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
-      "integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.7.tgz",
+      "integrity": "sha512-jCBs/0plmPsOnrKAfFQXRG2NFjlhZgjjcBLSmTnEhU8U6vVTsVe8ANeQJCHTl3gSsI4J+0emOoCgoKlmQPMgmA==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3219,13 +3746,13 @@
       }
     },
     "node_modules/object.hasown": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
-      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.3.tgz",
+      "integrity": "sha512-fFI4VcYpRHvSLXxP7yiZOMAd331cPfd2p7PFDVbgUsYOfCT3tICVqXWngbjr4m49OvsBwUBQ6O2uQoJvy3RexA==",
       "dev": true,
       "dependencies": {
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3277,6 +3804,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -3291,6 +3819,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
       "dependencies": {
         "p-limit": "^3.0.2"
       },
@@ -3335,16 +3864,11 @@
         "node": ">=4"
       }
     },
-    "node_modules/path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "peer": true
-    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3372,18 +3896,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
-    },
-    "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "peer": true,
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
     },
     "node_modules/pify": {
       "version": "4.0.1",
@@ -3468,17 +3980,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/pkg-dir": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-      "dependencies": {
-        "find-up": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3555,9 +4056,9 @@
       ]
     },
     "node_modules/rdf-canonize": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.3.0.tgz",
-      "integrity": "sha512-gfSNkMua/VWC1eYbSkVaL/9LQhFeOh0QULwv7Or0f+po8pMgQ1blYQFe1r9Mv2GJZXw88Cz/drnAnB9UlNnHfQ==",
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.4.0.tgz",
+      "integrity": "sha512-fUeWjrkOO0t1rg7B2fdyDTvngj+9RlUyL92vOdiB7c0FPguWVsniIMjEtHH+meLBO9rzkUlUzBVXgWrjI8P9LA==",
       "dependencies": {
         "setimmediate": "^1.0.5"
       },
@@ -3565,63 +4066,32 @@
         "node": ">=12"
       }
     },
-    "node_modules/rdf-ext": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rdf-ext/-/rdf-ext-2.1.0.tgz",
-      "integrity": "sha512-gUm6wynD9o2odOvpr+hY0Gr8iH8NNpQytu6Hqp8oY5rkYImWjs9TGh8ioy/BXaxkzcKNmU8j6ovlFSSvxCMOwA==",
+    "node_modules/rdf-data-factory": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.2.tgz",
+      "integrity": "sha512-TfQD63Lokabd09ES1jAtKK8AA6rkr9rwyUBGo6olOt1CE0Um36CUQIqytyf0am2ouBPR0l7SaHxCiMcPGHkt1A==",
+      "peer": true,
       "dependencies": {
-        "@rdfjs/data-model": "^2.0.0",
-        "@rdfjs/dataset": "^2.0.0",
-        "@rdfjs/environment": "^0.1.0",
-        "@rdfjs/fetch-lite": "^3.1.0",
-        "@rdfjs/namespace": "^2.0.0",
-        "@rdfjs/normalize": "^2.0.0",
-        "@rdfjs/prefix-map": "^0.1.0",
-        "@rdfjs/score": "^0.1.1",
-        "@rdfjs/term-map": "^2.0.0",
-        "@rdfjs/term-set": "^2.0.0",
-        "@rdfjs/to-ntriples": "^2.0.0",
-        "@rdfjs/traverser": "^0.1.0",
-        "clownface": "^1.4.0",
-        "readable-stream": "^3.6.0"
+        "@rdfjs/types": "*"
       }
     },
-    "node_modules/rdf-ext/node_modules/@rdfjs/data-model": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
-      "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw==",
-      "bin": {
-        "rdfjs-data-model-test": "bin/test.js"
-      }
-    },
-    "node_modules/rdf-ext/node_modules/@rdfjs/namespace": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-2.0.0.tgz",
-      "integrity": "sha512-cBBvNrlSOah4z7u2vS74Lxng/ivELy6tNPjx+G/Ag14up8z5xmX8njn+U/mJ+nlcXO7nDGK4rgaAq7jtl9S3CQ==",
+    "node_modules/rdf-dataset-ext": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/rdf-dataset-ext/-/rdf-dataset-ext-1.1.0.tgz",
+      "integrity": "sha512-CH85RfRKN9aSlbju8T7aM8hgCSWMBsh2eh/tGxUUtWMN+waxi6iFDt8/r4PAEmKaEA82guimZJ4ISbmJ2rvWQg==",
       "dependencies": {
-        "@rdfjs/data-model": "^2.0.0"
-      }
-    },
-    "node_modules/rdf-ext/node_modules/@rdfjs/term-map": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/term-map/-/term-map-2.0.0.tgz",
-      "integrity": "sha512-z0K8AgLsJGTrh+dGkXNl/oT9vBdMei4xq1MIeGN360oimA81Q+ruQUKFCbYNRRZS03tVHPBzqXUal/DezFGPEA==",
-      "dependencies": {
-        "@rdfjs/to-ntriples": "^2.0.0"
+        "rdf-canonize": "^3.0.0",
+        "readable-stream": "3 - 4"
       }
     },
     "node_modules/rdf-js": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
       "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
+      "peer": true,
       "dependencies": {
         "@rdfjs/types": "*"
       }
-    },
-    "node_modules/rdf-normalize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rdf-normalize/-/rdf-normalize-1.0.0.tgz",
-      "integrity": "sha512-1ocjoxovKc4+AyS4Tgtroay5R33yrtM2kQnAGvVaB0iGSRggukHxMJW0y8xTR7TwKZabS+7oMSQNMdbu/qTtCQ=="
     },
     "node_modules/rdf-transform-triple-to-quad": {
       "version": "1.0.2",
@@ -3630,6 +4100,48 @@
       "dependencies": {
         "@rdfjs/data-model": "^1.1.2",
         "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/rdfxml-streaming-parser": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-2.2.3.tgz",
+      "integrity": "sha512-HoH8urnga+YQ5sDY9ufRb0wg6FvwR284sSXpZ+fJE5X5Oej6dfzkFer81uBNZzyNmzJR1TpMYMznyXEjPMLhCA==",
+      "peer": true,
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@rubensworks/saxes": "^6.0.1",
+        "@types/readable-stream": "^2.3.13",
+        "buffer": "^6.0.3",
+        "rdf-data-factory": "^1.1.0",
+        "readable-stream": "^4.0.0",
+        "relative-to-absolute-iri": "^1.0.0",
+        "validate-iri": "^1.0.0"
+      }
+    },
+    "node_modules/rdfxml-streaming-parser/node_modules/@types/readable-stream": {
+      "version": "2.3.15",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-2.3.15.tgz",
+      "integrity": "sha512-oM5JSKQCcICF1wvGgmecmHldZ48OZamtMxcGGVICOJA8o8cahXC1zEVAif8iwoc5j8etxFaRFnf095+CDsuoFQ==",
+      "peer": true,
+      "dependencies": {
+        "@types/node": "*",
+        "safe-buffer": "~5.1.1"
+      }
+    },
+    "node_modules/rdfxml-streaming-parser/node_modules/readable-stream": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.4.2.tgz",
+      "integrity": "sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==",
+      "peer": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/react-is": {
@@ -3646,10 +4158,15 @@
         "readable-stream": "^2.3.3"
       }
     },
+    "node_modules/readable-error/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
     "node_modules/readable-error/node_modules/readable-stream": {
-      "version": "2.3.7",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -3660,11 +4177,6 @@
         "util-deprecate": "~1.0.1"
       }
     },
-    "node_modules/readable-error/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-    },
     "node_modules/readable-error/node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -3674,9 +4186,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -3743,6 +4255,12 @@
         "url": "https://github.com/sponsors/mysticatea"
       }
     },
+    "node_modules/relative-to-absolute-iri": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.7.tgz",
+      "integrity": "sha512-Xjyl4HmIzg2jzK/Un2gELqbcE8Fxy85A/aLSHE6PE/3+OGsFwmKVA1vRyGaz6vLWSqLDMHA+5rjD/xbibSQN1Q==",
+      "peer": true
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -3773,6 +4291,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
@@ -3797,6 +4316,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
       "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3833,36 +4353,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/safe-array-concat/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
-    },
     "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/safe-identifier": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
-      "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
-      "peer": true
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/safe-regex-test": {
       "version": "1.0.0",
@@ -3965,9 +4459,9 @@
       }
     },
     "node_modules/sparql-http-client": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/sparql-http-client/-/sparql-http-client-2.4.1.tgz",
-      "integrity": "sha512-w1rsSZW/0/byHml/veP4A1IZjEzjzphPr/iee1c20aG+RDEJC+2lAefXGTKZH58E7SSUoXqFW+hfwjVl5K2ecQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/sparql-http-client/-/sparql-http-client-2.4.2.tgz",
+      "integrity": "sha512-b7KBjs3BEJVQJAbWeaTx4EdBSOU1L0KfWLVgnkeRyBUoSTI8F1kTHuX7wzme/+UlfCS2zYsKGdpma5DwdaVRBQ==",
       "dependencies": {
         "@rdfjs/data-model": "^1.1.2",
         "@rdfjs/parser-n3": "^1.1.3",
@@ -4045,9 +4539,9 @@
       }
     },
     "node_modules/standard-engine": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-15.0.0.tgz",
-      "integrity": "sha512-4xwUhJNo1g/L2cleysUqUv7/btn7GEbYJvmgKrQ2vd/8pkTmN8cpqAZg+BT8Z1hNeEH787iWUdOpL8fmApLtxA==",
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-15.1.0.tgz",
+      "integrity": "sha512-VHysfoyxFu/ukT+9v49d4BRXIokFRZuH3z1VRxzFArZdjSCFpro6rEIU3ji7e4AoAtuSfKBkiOmsrDqKW5ZSRw==",
       "dev": true,
       "funding": [
         {
@@ -4090,27 +4584,39 @@
         "safe-buffer": "~5.2.0"
       }
     },
-    "node_modules/string-to-stream": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/string-to-stream/-/string-to-stream-3.0.1.tgz",
-      "integrity": "sha512-Hl092MV3USJuUCC6mfl9sPzGloA3K5VwdIeJjYIkXY/8K+mUvaeEabWJgArp+xXrsWxCajeT2pc4axbVhIZJyg==",
-      "dependencies": {
-        "readable-stream": "^3.4.0"
-      }
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
     },
     "node_modules/string.prototype.matchall": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
-      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.10.tgz",
+      "integrity": "sha512-rGXbGmOEosIQi6Qva94HUjgPs9vKW+dkG7Y8Q5O2OYkWL6wFaTRZO8zM4mhP94uX55wgyrXzfS2aGtGzUL7EJQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "get-intrinsic": "^1.1.3",
+        "define-properties": "^1.2.0",
+        "es-abstract": "^1.22.1",
+        "get-intrinsic": "^1.2.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.4.3",
+        "internal-slot": "^1.0.5",
+        "regexp.prototype.flags": "^1.5.0",
+        "set-function-name": "^2.0.0",
         "side-channel": "^1.0.4"
       },
       "funding": {
@@ -4234,75 +4740,10 @@
         "readable-stream": "2 || 3"
       }
     },
-    "node_modules/to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "peer": true,
-      "dependencies": {
-        "is-number": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=8.0"
-      }
-    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "node_modules/ts-morph": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-17.0.1.tgz",
-      "integrity": "sha512-10PkHyXmrtsTvZSL+cqtJLTgFXkU43Gd0JCc0Rw6GchWbqKe0Rwgt1v3ouobTZwQzF1mGhDeAlWYBMGRV7y+3g==",
-      "peer": true,
-      "dependencies": {
-        "@ts-morph/common": "~0.18.0",
-        "code-block-writer": "^11.0.3"
-      }
-    },
-    "node_modules/ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "peer": true,
-      "dependencies": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      },
-      "bin": {
-        "ts-node": "dist/bin.js",
-        "ts-node-cwd": "dist/bin-cwd.js",
-        "ts-node-esm": "dist/bin-esm.js",
-        "ts-node-script": "dist/bin-script.js",
-        "ts-node-transpile-only": "dist/bin-transpile.js",
-        "ts-script": "dist/bin-script-deprecated.js"
-      },
-      "peerDependencies": {
-        "@swc/core": ">=1.2.50",
-        "@swc/wasm": ">=1.2.50",
-        "@types/node": "*",
-        "typescript": ">=2.7"
-      },
-      "peerDependenciesMeta": {
-        "@swc/core": {
-          "optional": true
-        },
-        "@swc/wasm": {
-          "optional": true
-        }
-      }
     },
     "node_modules/tsconfig-paths": {
       "version": "3.14.2",
@@ -4415,19 +4856,6 @@
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
     },
-    "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "peer": true,
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=4.2.0"
-      }
-    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -4443,13 +4871,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-      "engines": {
-        "node": ">= 10.0.0"
-      }
+    "node_modules/undici-types": {
+      "version": "5.25.3",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.25.3.tgz",
+      "integrity": "sha512-Ga1jfYwRn7+cP9v8auvEXN1rX3sWqlayd4HP7OKk4mZWylEmu3KzXDUGrQUN6Ol7qo1gPvB2e5gX6udnyEPgdA=="
     },
     "node_modules/uri-js": {
       "version": "4.4.1",
@@ -4465,10 +4890,10 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
-    "node_modules/v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
+    "node_modules/validate-iri": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/validate-iri/-/validate-iri-1.0.1.tgz",
+      "integrity": "sha512-gLXi7351CoyVVQw8XE5sgpYawRKatxE7kj/xmCxXOZS1kMdtcqC0ILIqLuVEVnAUQSL/evOGG3eQ+8VgbdnstA==",
       "peer": true
     },
     "node_modules/version-guard": {
@@ -4559,12 +4984,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/which-builtin-type/node_modules/isarray": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "dev": true
-    },
     "node_modules/which-collection": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
@@ -4614,15 +5033,14 @@
       }
     },
     "node_modules/xmlbuilder2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.0.2.tgz",
-      "integrity": "sha512-h4MUawGY21CTdhV4xm3DG9dgsqyhDkZvVJBx88beqX8wJs3VgyGQgAn5VreHuae6unTQxh115aMK5InCVmOIKw==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.1.1.tgz",
+      "integrity": "sha512-WCSfbfZnQDdLQLiMdGUQpMxxckeQ4oZNMNhLVkcekTu7xhD4tuUDyAPoY8CwXvBYE6LwBHd6QW2WZXlOWr1vCw==",
       "dependencies": {
         "@oozcitak/dom": "1.15.10",
         "@oozcitak/infra": "1.0.8",
         "@oozcitak/util": "8.3.8",
-        "@types/node": "*",
-        "js-yaml": "3.14.0"
+        "js-yaml": "3.14.1"
       },
       "engines": {
         "node": ">=12.0"
@@ -4637,9 +5055,9 @@
       }
     },
     "node_modules/xmlbuilder2/node_modules/js-yaml": {
-      "version": "3.14.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-      "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
       "dependencies": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -4648,3483 +5066,29 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "peer": true
+    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
-    "node_modules/yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "peer": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    }
-  },
-  "dependencies": {
-    "@aashutoshrathi/word-wrap": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-      "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-      "dev": true
-    },
-    "@cspotcode/source-map-support": {
-      "version": "0.8.1",
-      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
-      "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "peer": true,
-      "requires": {
-        "@jridgewell/trace-mapping": "0.3.9"
-      }
-    },
-    "@eslint-community/eslint-utils": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-      "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
-      "dev": true,
-      "requires": {
-        "eslint-visitor-keys": "^3.3.0"
-      }
-    },
-    "@eslint-community/regexpp": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.1.tgz",
-      "integrity": "sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==",
-      "dev": true
-    },
-    "@eslint/eslintrc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
-      "integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      }
-    },
-    "@eslint/js": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
-      "integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==",
-      "dev": true
-    },
-    "@humanwhocodes/config-array": {
-      "version": "0.11.13",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-      "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
-      "dev": true,
-      "requires": {
-        "@humanwhocodes/object-schema": "^2.0.1",
-        "debug": "^4.1.1",
-        "minimatch": "^3.0.5"
-      }
-    },
-    "@humanwhocodes/module-importer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
-      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true
-    },
-    "@humanwhocodes/object-schema": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-      "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
-      "dev": true
-    },
-    "@jridgewell/resolve-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "peer": true
-    },
-    "@jridgewell/sourcemap-codec": {
-      "version": "1.4.14",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "peer": true
-    },
-    "@jridgewell/trace-mapping": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
-      "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "peer": true,
-      "requires": {
-        "@jridgewell/resolve-uri": "^3.0.3",
-        "@jridgewell/sourcemap-codec": "^1.4.10"
-      }
-    },
-    "@nodelib/fs.scandir": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
-      "requires": {
-        "@nodelib/fs.stat": "2.0.5",
-        "run-parallel": "^1.1.9"
-      }
-    },
-    "@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="
-    },
-    "@nodelib/fs.walk": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
-      "requires": {
-        "@nodelib/fs.scandir": "2.1.5",
-        "fastq": "^1.6.0"
-      }
-    },
-    "@oozcitak/dom": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
-      "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
-      "requires": {
-        "@oozcitak/infra": "1.0.8",
-        "@oozcitak/url": "1.0.4",
-        "@oozcitak/util": "8.3.8"
-      }
-    },
-    "@oozcitak/infra": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
-      "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
-      "requires": {
-        "@oozcitak/util": "8.3.8"
-      }
-    },
-    "@oozcitak/url": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
-      "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
-      "requires": {
-        "@oozcitak/infra": "1.0.8",
-        "@oozcitak/util": "8.3.8"
-      }
-    },
-    "@oozcitak/util": {
-      "version": "8.3.8",
-      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
-      "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ=="
-    },
-    "@rdf-esm/data-model": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/@rdf-esm/data-model/-/data-model-0.5.4.tgz",
-      "integrity": "sha512-EINrtebCO6aT9e8vLmkaFFs317sCRj9cdFlKexvZA+7bLwcKrmcQLwC+nnnyBurtypHzWlokbLvp1SZHQWiH3w==",
-      "requires": {
-        "@rdfjs/data-model": "^1.2"
-      }
-    },
-    "@rdf-esm/namespace": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/@rdf-esm/namespace/-/namespace-0.5.5.tgz",
-      "integrity": "sha512-JF26H4Mx+N93qIOu3KMsjdUW6As+dhvq9wP2Q03fjiS4l1rG+gKwfKUop8CHtVETVeDcNsO3+Srrq0wiQgAPDw==",
-      "requires": {
-        "@rdf-esm/data-model": "^0.5.1",
-        "@rdfjs/namespace": "^1.1.0",
-        "@types/rdfjs__namespace": "*"
-      }
-    },
-    "@rdf-esm/term-map": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@rdf-esm/term-map/-/term-map-0.5.1.tgz",
-      "integrity": "sha512-Yq/5hBFt90q/eru2i9NVBxAayaGI/oWTPH1+6VoFueiaKSVl4Pf4lMX98/Hg/si5Ql0gG4B4wqBbFItl4LDI0A==",
-      "requires": {
-        "@rdf-esm/to-ntriples": "^0.6.0",
-        "@rdfjs/term-map": "^1.0.0"
-      }
-    },
-    "@rdf-esm/to-ntriples": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@rdf-esm/to-ntriples/-/to-ntriples-0.6.0.tgz",
-      "integrity": "sha512-984lPZhKmFuLuJ74Q8SqtwzDDS43V98QXjpvu6jmlXEF2xQHwItmQk0AZ9Cyf26f3EiTVfLn3JHGWwkB0AK8IQ==",
-      "requires": {
-        "@rdfjs/to-ntriples": "^2.0.0"
-      }
-    },
-    "@rdfjs/data-model": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
-      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
-      "requires": {
-        "@rdfjs/types": ">=1.0.1"
-      }
-    },
-    "@rdfjs/dataset": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-2.0.1.tgz",
-      "integrity": "sha512-hDIaXpUmU/ZdofX/BMFDAchkhN/AjmP5dMCOuVL2VCqWuFjeQxd2KV84E4+7S2Biw8tjEFhPBeQZP7KW+ARV7Q=="
-    },
-    "@rdfjs/environment": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/environment/-/environment-0.1.1.tgz",
-      "integrity": "sha512-dU3wXZQ0nwJq17XH5/IWsRj980KkMR+lXS2LAfhzfaAyaZ09cQsjV+o2AQ4hp7r4PNMVQIz+8NAFE66WkSWIQw==",
-      "requires": {
-        "@rdfjs/data-model": "^1.3.2",
-        "@rdfjs/dataset": "^1.1.1",
-        "@rdfjs/fetch-lite": "^2.1.2",
-        "@rdfjs/namespace": "^1.1.0",
-        "@rdfjs/sink-map": "^1.0.1",
-        "@rdfjs/term-map": "^1.1.0",
-        "@rdfjs/term-set": "^1.1.0"
-      },
-      "dependencies": {
-        "@rdfjs/dataset": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.1.tgz",
-          "integrity": "sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==",
-          "requires": {
-            "@rdfjs/data-model": "^1.2.0"
-          }
-        },
-        "@rdfjs/fetch-lite": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/@rdfjs/fetch-lite/-/fetch-lite-2.1.2.tgz",
-          "integrity": "sha512-M66ShQbQH94/XdavOuCWLu5TFbx4pHxNLolC7oUvmIZI03mQOYyapEinGaaUozpdQoY8iOrekree4OORdRKFCA==",
-          "requires": {
-            "isstream": "^0.1.2",
-            "nodeify-fetch": "^2.2.1",
-            "readable-stream": "^3.3.0"
-          }
-        },
-        "@rdfjs/term-set": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/@rdfjs/term-set/-/term-set-1.1.0.tgz",
-          "integrity": "sha512-QQ4yzVe1Rvae/GN9SnOhweHNpaxQtnAjeOVciP/yJ0Gfxtbphy2tM56ZsRLV04Qq5qMcSclZIe6irYyEzx/UwQ==",
-          "requires": {
-            "@rdfjs/to-ntriples": "^2.0.0"
-          }
-        },
-        "nodeify-fetch": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/nodeify-fetch/-/nodeify-fetch-2.2.2.tgz",
-          "integrity": "sha512-4b1Jysy9RGyya0wJpseTQyxUgSbx6kw9ocHTY0OFRXWlxa2Uy5PrSo/P/nwoUn59rBR9YKty2kd7g4LKXmsZVA==",
-          "requires": {
-            "@zazuko/node-fetch": "^2.6.6",
-            "concat-stream": "^1.6.0",
-            "cross-fetch": "^3.0.4",
-            "readable-error": "^1.0.0",
-            "readable-stream": "^3.5.0"
-          }
-        }
-      }
-    },
-    "@rdfjs/fetch-lite": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/fetch-lite/-/fetch-lite-3.1.0.tgz",
-      "integrity": "sha512-S/85k+qM5I3Zyv9jPYOPLIpZycRZ0eX3tRga7HiwkrHFANqu/jZ9HpKQ9u8iohcX70QDl5Jsng/UKFdplRDQ8g==",
-      "requires": {
-        "isstream": "^0.1.2",
-        "nodeify-fetch": "^3.0.0",
-        "readable-stream": "^3.6.0"
-      }
-    },
-    "@rdfjs/namespace": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-1.1.0.tgz",
-      "integrity": "sha512-utO5rtaOKxk8B90qzaQ0N+J5WrCI28DtfAY/zExCmXE7cOfC5uRI/oMKbLaVEPj2P7uArekt/T4IPATtj7Tjug==",
-      "requires": {
-        "@rdfjs/data-model": "^1.1.0"
-      }
-    },
-    "@rdfjs/normalize": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/normalize/-/normalize-2.0.0.tgz",
-      "integrity": "sha512-jOSdIKz9r/oPI9nuWXMTYzFaCbrFQj9qEOPdqs1/7oAR1JTvqpS69HVZPkVqbH+WhL52PJbBXyA5QadoyNLgpQ==",
-      "requires": {
-        "rdf-canonize": "^3.0.0"
-      }
-    },
-    "@rdfjs/parser-n3": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@rdfjs/parser-n3/-/parser-n3-1.1.4.tgz",
-      "integrity": "sha512-PUKSNlfD2Zq3GcQZuOF2ndfrLbc+N96FUe2gNIzARlR2er0BcOHBHEFUJvVGg1Xmsg3hVKwfg0nwn1JZ7qKKMw==",
-      "requires": {
-        "@rdfjs/data-model": "^1.0.1",
-        "@rdfjs/sink": "^1.0.2",
-        "n3": "^1.3.5",
-        "readable-stream": "^3.6.0",
-        "readable-to-readable": "^0.1.0"
-      }
-    },
-    "@rdfjs/prefix-map": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/prefix-map/-/prefix-map-0.1.0.tgz",
-      "integrity": "sha512-F3B2EXysSX0wu7gE5puJONPJVxTQLGroDTMvR/9ZRsBYffNlHZmtT8H2fWi5UiPbVxXBiMElN+Y6MIuinYmKog==",
-      "requires": {
-        "readable-stream": "^3.6.0"
-      }
-    },
-    "@rdfjs/score": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/score/-/score-0.1.1.tgz",
-      "integrity": "sha512-+t9Sf5nFUJTvH8X2Xy7H+egLKIyVCwlDzCGrWThSrSCmIENcC9n3+GkMMImnsmYDeSXaWi3awcI1f1TmA84FIQ==",
-      "requires": {
-        "@rdfjs/data-model": "^2.0.1",
-        "@rdfjs/term-map": "^2.0.0",
-        "@rdfjs/term-set": "^2.0.1",
-        "@rdfjs/to-ntriples": "^2.0.0"
-      },
-      "dependencies": {
-        "@rdfjs/data-model": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
-          "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw=="
-        },
-        "@rdfjs/term-map": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@rdfjs/term-map/-/term-map-2.0.0.tgz",
-          "integrity": "sha512-z0K8AgLsJGTrh+dGkXNl/oT9vBdMei4xq1MIeGN360oimA81Q+ruQUKFCbYNRRZS03tVHPBzqXUal/DezFGPEA==",
-          "requires": {
-            "@rdfjs/to-ntriples": "^2.0.0"
-          }
-        }
-      }
-    },
-    "@rdfjs/sink": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-1.0.3.tgz",
-      "integrity": "sha512-2KfYa8mAnptRNeogxhQqkWNXqfYVWO04jQThtXKepySrIwYmz83+WlevQtA4VDLFe+kFd2TwgL29ekPe5XVUfA=="
-    },
-    "@rdfjs/sink-map": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/sink-map/-/sink-map-1.0.1.tgz",
-      "integrity": "sha512-PRp5TjULHe2oRcupR80SClZ/l50wnSuX2Pl+TlkcRazt1w7AT86kLmQYFbDfjqGM7uDwSyD6evLJxXBDf5UuvQ=="
-    },
-    "@rdfjs/term-map": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/term-map/-/term-map-1.1.0.tgz",
-      "integrity": "sha512-utCLVQEZdEL664XoYuBQwMIk0Q5MD6qNPEt12DcmuAlQUS0b0kQ+WL50wyJP1BpWYjOJLokIVTUtphZWnj25BQ==",
-      "requires": {
-        "@rdfjs/to-ntriples": "^2.0.0"
-      }
-    },
-    "@rdfjs/term-set": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@rdfjs/term-set/-/term-set-2.0.1.tgz",
-      "integrity": "sha512-ZD8IwSY7tPpevs2iaQEsesAu8c7TO4GKHQHObbehUE4odKa9BuhuimdNuYwBoyVprTtHARaW6VW+0Jsu7ehD+Q==",
-      "requires": {
-        "@rdfjs/to-ntriples": "^2.0.0"
-      }
-    },
-    "@rdfjs/to-ntriples": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-2.0.0.tgz",
-      "integrity": "sha512-nDhpfhx6W6HKsy4HjyLp3H1nbrX1CiUCWhWQwKcYZX1s9GOjcoQTwY7GUUbVec0hzdJDQBR6gnjxtENBDt482Q=="
-    },
-    "@rdfjs/traverser": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/traverser/-/traverser-0.1.0.tgz",
-      "integrity": "sha512-9vYPgEg0tgYuOuLTXoyr33NRMvWULs2KcqfEG2afBny6XPf6Rfj3o9ONokj0OZQhj5ZVY+t6yIY08Dz1dtphMg=="
-    },
-    "@rdfjs/types": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.0.tgz",
-      "integrity": "sha512-5zm8bN2/CC634dTcn/0AhTRLaQRjXDZs3QfcAsQKNturHT7XVWcKy/8p3P5gXl+YkZTAmy7T5M/LyiT/jbkENw==",
-      "requires": {
-        "@types/node": "*"
-      }
-    },
-    "@tpluscode/rdf-ns-builders": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-ns-builders/-/rdf-ns-builders-2.0.1.tgz",
-      "integrity": "sha512-P/pwfjhcj/JOZF3epheHiDd/f9tSkceydQBqBuqThpNX2NIg+4BSgwtG2YfKBa24mmGFfyzN6RVeFclhA8wZBw==",
-      "requires": {
-        "@rdf-esm/data-model": "^0.5.4",
-        "@rdf-esm/namespace": "^0.5.1",
-        "@rdfjs/types": "*",
-        "commander": "^7.2.0",
-        "fs-extra": "^10.0.0"
-      }
-    },
-    "@tpluscode/rdf-string": {
-      "version": "0.2.26",
-      "resolved": "https://registry.npmjs.org/@tpluscode/rdf-string/-/rdf-string-0.2.26.tgz",
-      "integrity": "sha512-zfNGMmY8D9jVuJ9qHwNrIWMwhibIkO42/1KtCfo59m4vXYTfJrXcn1ny9pj5kuhbpSubRbJ69zmYxP4UrXVPQw==",
-      "requires": {
-        "@rdf-esm/data-model": "^0.5.3",
-        "@rdf-esm/term-map": "^0.5.0",
-        "@rdfjs/types": "*",
-        "@tpluscode/rdf-ns-builders": "^2",
-        "@zazuko/rdf-vocabularies": "*"
-      }
-    },
-    "@ts-morph/common": {
-      "version": "0.18.1",
-      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.18.1.tgz",
-      "integrity": "sha512-RVE+zSRICWRsfrkAw5qCAK+4ZH9kwEFv5h0+/YeHTLieWP7F4wWq4JsKFuNWG+fYh/KF+8rAtgdj5zb2mm+DVA==",
-      "peer": true,
-      "requires": {
-        "fast-glob": "^3.2.12",
-        "minimatch": "^5.1.0",
-        "mkdirp": "^1.0.4",
-        "path-browserify": "^1.0.1"
-      },
-      "dependencies": {
-        "brace-expansion": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-          "peer": true,
-          "requires": {
-            "balanced-match": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-          "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
-          "peer": true,
-          "requires": {
-            "brace-expansion": "^2.0.1"
-          }
-        }
-      }
-    },
-    "@tsconfig/node10": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "peer": true
-    },
-    "@tsconfig/node12": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "peer": true
-    },
-    "@tsconfig/node14": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "peer": true
-    },
-    "@tsconfig/node16": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "peer": true
-    },
-    "@types/json5": {
-      "version": "0.0.29",
-      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
-      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
-      "dev": true
-    },
-    "@types/node": {
-      "version": "18.11.14",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.11.14.tgz",
-      "integrity": "sha512-0KXV57tENYmmJMl+FekeW9V3O/rlcqGQQJ/hNh9r8pKIj304pskWuEd8fCyNT86g/TpO0gcOTiLzsHLEURFMIQ=="
-    },
-    "@types/rdfjs__namespace": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@types/rdfjs__namespace/-/rdfjs__namespace-2.0.0.tgz",
-      "integrity": "sha512-bpVmmBrwg4plwfSNtwbwIYtZEpGFPWHTlfa1iftSY03+V+2wq+pfZxYkZwrhZwyh/Dxy5usIrVt04Rvigc4uXg==",
-      "requires": {
-        "rdf-js": "^4.0.2"
-      }
-    },
-    "@ungap/structured-clone": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-      "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-      "dev": true
-    },
-    "@zazuko/node-fetch": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/@zazuko/node-fetch/-/node-fetch-2.6.6.tgz",
-      "integrity": "sha512-mrEqq7BJyNBlK5oT7U1S0EfLbFPpVHLXQJswhrN8Mv/3BKmWIBtMBaphK8AXF7XEhgK9vzRs/f3AIG8oHlPdpg==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      }
-    },
-    "@zazuko/rdf-vocabularies": {
-      "version": "2022.11.28",
-      "resolved": "https://registry.npmjs.org/@zazuko/rdf-vocabularies/-/rdf-vocabularies-2022.11.28.tgz",
-      "integrity": "sha512-fg3GwDMI2ooS6VA2C23hFy5BrY5WO4lwjwa0/jYLYUpEHorTk430X0MvKQcfEgyz6U4NO8QDS8jz1CGvC4YLAw==",
-      "requires": {
-        "@rdfjs/parser-n3": "^1.1.4",
-        "commander": "^5.0.0",
-        "pkg-dir": "^5.0.0",
-        "rdf-ext": "^1.3.5",
-        "readable-stream": "^3.6.0",
-        "string-to-stream": "^3.0.1"
-      },
-      "dependencies": {
-        "@rdfjs/dataset": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.1.tgz",
-          "integrity": "sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==",
-          "requires": {
-            "@rdfjs/data-model": "^1.2.0"
-          }
-        },
-        "@rdfjs/to-ntriples": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-1.0.2.tgz",
-          "integrity": "sha512-ngw5XAaGHjgGiwWWBPGlfdCclHftonmbje5lMys4G2j4NvfExraPIuRZgjSnd5lg4dnulRVUll8tRbgKO+7EDA=="
-        },
-        "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
-        },
-        "rdf-ext": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/rdf-ext/-/rdf-ext-1.3.5.tgz",
-          "integrity": "sha512-LS/waItwp5aGY9Ay7y147HxWLIaSvw4r172S995aGwVkvg0KwUA0NY8w61p/LoFdQ4V6mzxQdVoRN6x/6OaK0w==",
-          "requires": {
-            "@rdfjs/data-model": "^1.3.3",
-            "@rdfjs/dataset": "^1.1.1",
-            "@rdfjs/to-ntriples": "^1.0.1",
-            "rdf-normalize": "^1.0.0",
-            "readable-stream": "^3.6.0"
-          }
-        }
-      }
-    },
-    "abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "requires": {
-        "event-target-shim": "^5.0.0"
-      }
-    },
-    "acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
-    },
-    "acorn-jsx": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "acorn-walk": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-      "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "peer": true
-    },
-    "ajv": {
-      "version": "6.12.6",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
-      "requires": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
-      }
-    },
-    "ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true
-    },
-    "ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "requires": {
-        "color-convert": "^2.0.1"
-      }
-    },
-    "arg": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "peer": true
-    },
-    "argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
-    },
-    "array-buffer-byte-length": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.0.tgz",
-      "integrity": "sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "is-array-buffer": "^3.0.1"
-      }
-    },
-    "array-includes": {
-      "version": "3.1.7",
-      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.7.tgz",
-      "integrity": "sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1",
-        "is-string": "^1.0.7"
-      }
-    },
-    "array.prototype.findlastindex": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.3.tgz",
-      "integrity": "sha512-LzLoiOMAxvy+Gd3BAq3B7VeIgPdo+Q8hthvKtXybMvRV0jrXfJM/t8mw7nNlpEcVlVUnCnM2KSX4XU5HmpodOA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0",
-        "get-intrinsic": "^1.2.1"
-      }
-    },
-    "array.prototype.flat": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.2.tgz",
-      "integrity": "sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
-      }
-    },
-    "array.prototype.flatmap": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.2.tgz",
-      "integrity": "sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "es-shim-unscopables": "^1.0.0"
-      }
-    },
-    "array.prototype.tosorted": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.1.tgz",
-      "integrity": "sha512-pZYPXPRl2PqWcsUs6LOMn+1f1532nEoPTYowBtqLwAW+W8vSVhkIGnmOX1t/UQjD6YGI0vcD2B1U7ZFGQH9jnQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "es-shim-unscopables": "^1.0.0",
-        "get-intrinsic": "^1.1.3"
-      }
-    },
-    "arraybuffer.prototype.slice": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.2.tgz",
-      "integrity": "sha512-yMBKppFur/fbHu9/6USUe03bZ4knMYiwFBcyiaXB8Go0qNehwX6inYPzK9U0NeQvGxKthcmHcaR8P5MStSRBAw==",
-      "dev": true,
-      "requires": {
-        "array-buffer-byte-length": "^1.0.0",
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1",
-        "is-array-buffer": "^3.0.2",
-        "is-shared-array-buffer": "^1.0.2"
-      }
-    },
-    "asynciterator.prototype": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/asynciterator.prototype/-/asynciterator.prototype-1.0.0.tgz",
-      "integrity": "sha512-wwHYEIS0Q80f5mosx3L/dfG5t5rjEa9Ft51GTaNt862EnpyGHpgz2RkZvLPp1oF5TnAiTohkEKVEu8pQPJI7Vg==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.3"
-      }
-    },
-    "available-typed-arrays": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
-      "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==",
-      "dev": true
-    },
-    "balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-    },
-    "base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
-    },
-    "brace-expansion": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "peer": true,
-      "requires": {
-        "fill-range": "^7.0.1"
-      }
-    },
-    "buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "requires": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
-    },
-    "builtins": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-      "dev": true,
-      "requires": {
-        "semver": "^7.0.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
-    "call-bind": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
-      "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.2",
-        "get-intrinsic": "^1.2.1",
-        "set-function-length": "^1.1.1"
-      }
-    },
-    "callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true
-    },
-    "chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      }
-    },
-    "clownface": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/clownface/-/clownface-1.5.1.tgz",
-      "integrity": "sha512-Ko8N/UFsnhEGmPlyE1bUFhbRhVgDbxqlIjcqxtLysc4dWaY0A7iCdg3savhAxs7Lheb7FCygIyRh7ADYZWVIng==",
-      "requires": {
-        "@rdfjs/data-model": "^1.1.0",
-        "@rdfjs/namespace": "^1.0.0"
-      }
-    },
-    "code-block-writer": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-11.0.3.tgz",
-      "integrity": "sha512-NiujjUFB4SwScJq2bwbYUtXbZhBSlY6vYzm++3Q6oC+U+injTqfPYFK8wS9COOmb2lueqp0ZRB4nK1VYeHgNyw==",
-      "peer": true
-    },
-    "color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "requires": {
-        "color-name": "~1.1.4"
-      }
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "commander": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
-      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
-    },
-    "concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true
-    },
-    "concat-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
-      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "inherits": "^2.0.3",
-        "readable-stream": "^2.2.2",
-        "typedarray": "^0.0.6"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
-    "create-require": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "peer": true
-    },
-    "cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
-      "requires": {
-        "node-fetch": "2.6.7"
-      },
-      "dependencies": {
-        "node-fetch": {
-          "version": "2.6.7",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-          "requires": {
-            "whatwg-url": "^5.0.0"
-          }
-        }
-      }
-    },
-    "cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
-      "requires": {
-        "path-key": "^3.1.0",
-        "shebang-command": "^2.0.0",
-        "which": "^2.0.1"
-      }
-    },
-    "data-uri-to-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.0.tgz",
-      "integrity": "sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA=="
-    },
-    "debug": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
-      "requires": {
-        "ms": "2.1.2"
-      }
-    },
-    "deep-is": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
-      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true
-    },
-    "define-data-property": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
-      "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.2.1",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
-      }
-    },
-    "define-properties": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
-      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
-      "requires": {
-        "define-data-property": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "object-keys": "^1.1.1"
-      }
-    },
-    "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "peer": true
-    },
-    "doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
-      "requires": {
-        "esutils": "^2.0.2"
-      }
-    },
-    "dotenv": {
-      "version": "16.0.3",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
-      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
-    },
-    "end-of-stream": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-      "requires": {
-        "once": "^1.4.0"
-      }
-    },
-    "error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "^0.2.1"
-      }
-    },
-    "es-abstract": {
-      "version": "1.22.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.22.3.tgz",
-      "integrity": "sha512-eiiY8HQeYfYH2Con2berK+To6GrK2RxbPawDkGq4UiCQQfZHb6wX9qQqkbpPqaxQFcl8d9QzZqo0tGE0VcrdwA==",
-      "dev": true,
-      "requires": {
-        "array-buffer-byte-length": "^1.0.0",
-        "arraybuffer.prototype.slice": "^1.0.2",
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.5",
-        "es-set-tostringtag": "^2.0.1",
-        "es-to-primitive": "^1.2.1",
-        "function.prototype.name": "^1.1.6",
-        "get-intrinsic": "^1.2.2",
-        "get-symbol-description": "^1.0.0",
-        "globalthis": "^1.0.3",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0",
-        "internal-slot": "^1.0.5",
-        "is-array-buffer": "^3.0.2",
-        "is-callable": "^1.2.7",
-        "is-negative-zero": "^2.0.2",
-        "is-regex": "^1.1.4",
-        "is-shared-array-buffer": "^1.0.2",
-        "is-string": "^1.0.7",
-        "is-typed-array": "^1.1.12",
-        "is-weakref": "^1.0.2",
-        "object-inspect": "^1.13.1",
-        "object-keys": "^1.1.1",
-        "object.assign": "^4.1.4",
-        "regexp.prototype.flags": "^1.5.1",
-        "safe-array-concat": "^1.0.1",
-        "safe-regex-test": "^1.0.0",
-        "string.prototype.trim": "^1.2.8",
-        "string.prototype.trimend": "^1.0.7",
-        "string.prototype.trimstart": "^1.0.7",
-        "typed-array-buffer": "^1.0.0",
-        "typed-array-byte-length": "^1.0.0",
-        "typed-array-byte-offset": "^1.0.0",
-        "typed-array-length": "^1.0.4",
-        "unbox-primitive": "^1.0.2",
-        "which-typed-array": "^1.1.13"
-      }
-    },
-    "es-iterator-helpers": {
-      "version": "1.0.15",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.0.15.tgz",
-      "integrity": "sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==",
-      "dev": true,
-      "requires": {
-        "asynciterator.prototype": "^1.0.0",
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.1",
-        "es-abstract": "^1.22.1",
-        "es-set-tostringtag": "^2.0.1",
-        "function-bind": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
-        "globalthis": "^1.0.3",
-        "has-property-descriptors": "^1.0.0",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.5",
-        "iterator.prototype": "^1.1.2",
-        "safe-array-concat": "^1.0.1"
-      }
-    },
-    "es-set-tostringtag": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.2.tgz",
-      "integrity": "sha512-BuDyupZt65P9D2D2vA/zqcI3G5xRsklm5N3xCwuiy+/vKy8i0ifdsQP1sLgO4tZDSCaQUSnmC48khknGMV3D2Q==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.2.2",
-        "has-tostringtag": "^1.0.0",
-        "hasown": "^2.0.0"
-      }
-    },
-    "es-shim-unscopables": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz",
-      "integrity": "sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==",
-      "dev": true,
-      "requires": {
-        "has": "^1.0.3"
-      }
-    },
-    "es-to-primitive": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
-      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.4",
-        "is-date-object": "^1.0.1",
-        "is-symbol": "^1.0.2"
-      }
-    },
-    "escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true
-    },
-    "eslint": {
-      "version": "8.52.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
-      "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
-      "dev": true,
-      "requires": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.2",
-        "@eslint/js": "8.52.0",
-        "@humanwhocodes/config-array": "^0.11.13",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
-        "@ungap/structured-clone": "^1.2.0",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.3",
-        "espree": "^9.6.1",
-        "esquery": "^1.4.2",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "globals": "^13.19.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
-      }
-    },
-    "eslint-config-standard": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-17.1.0.tgz",
-      "integrity": "sha512-IwHwmaBNtDK4zDHQukFDW5u/aTb8+meQWZvNFWkiGmbWjD6bqyuSSBxxXKkCftCUzc1zwCH2m/baCNDLGmuO5Q==",
-      "dev": true,
-      "requires": {}
-    },
-    "eslint-config-standard-jsx": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-standard-jsx/-/eslint-config-standard-jsx-11.0.0.tgz",
-      "integrity": "sha512-+1EV/R0JxEK1L0NGolAr8Iktm3Rgotx3BKwgaX+eAuSX8D952LULKtjgZD3F+e6SvibONnhLwoTi9DPxN5LvvQ==",
-      "dev": true,
-      "requires": {}
-    },
-    "eslint-import-resolver-node": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
-      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.2.7",
-        "is-core-module": "^2.13.0",
-        "resolve": "^1.22.4"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "eslint-module-utils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.8.0.tgz",
-      "integrity": "sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==",
-      "dev": true,
-      "requires": {
-        "debug": "^3.2.7"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
-      }
-    },
-    "eslint-plugin-es": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-4.1.0.tgz",
-      "integrity": "sha512-GILhQTnjYE2WorX5Jyi5i4dz5ALWxBIdQECVQavL6s7cI76IZTDWleTHkxz/QT3kvcs2QlGHvKLYsSlPOlPXnQ==",
-      "dev": true,
-      "requires": {
-        "eslint-utils": "^2.0.0",
-        "regexpp": "^3.0.0"
-      },
-      "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        },
-        "eslint-visitor-keys": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
-          "dev": true
-        }
-      }
-    },
-    "eslint-plugin-import": {
-      "version": "2.29.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.29.0.tgz",
-      "integrity": "sha512-QPOO5NO6Odv5lpoTkddtutccQjysJuFxoPS7fAHO+9m9udNHvTCPSAMW9zGAYj8lAIdr40I8yPCdUYrncXtrwg==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.1.7",
-        "array.prototype.findlastindex": "^1.2.3",
-        "array.prototype.flat": "^1.3.2",
-        "array.prototype.flatmap": "^1.3.2",
-        "debug": "^3.2.7",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.8.0",
-        "hasown": "^2.0.0",
-        "is-core-module": "^2.13.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.7",
-        "object.groupby": "^1.0.1",
-        "object.values": "^1.1.7",
-        "semver": "^6.3.1",
-        "tsconfig-paths": "^3.14.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        }
-      }
-    },
-    "eslint-plugin-n": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-15.7.0.tgz",
-      "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
-      "dev": true,
-      "requires": {
-        "builtins": "^5.0.1",
-        "eslint-plugin-es": "^4.1.0",
-        "eslint-utils": "^3.0.0",
-        "ignore": "^5.1.1",
-        "is-core-module": "^2.11.0",
-        "minimatch": "^3.1.2",
-        "resolve": "^1.22.1",
-        "semver": "^7.3.8"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "7.5.4",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-          "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
-          "dev": true,
-          "requires": {
-            "lru-cache": "^6.0.0"
-          }
-        }
-      }
-    },
-    "eslint-plugin-promise": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-6.1.1.tgz",
-      "integrity": "sha512-tjqWDwVZQo7UIPMeDReOpUgHCmCiH+ePnVT+5zVapL0uuHnegBUs2smM13CzOs2Xb5+MHMRFTs9v24yjba4Oig==",
-      "dev": true,
-      "requires": {}
-    },
-    "eslint-plugin-react": {
-      "version": "7.33.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.33.2.tgz",
-      "integrity": "sha512-73QQMKALArI8/7xGLNI/3LylrEYrlKZSb5C9+q3OtOewTnMQi5cT+aE9E41sLCmli3I9PGGmD1yiZydyo4FEPw==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.1.6",
-        "array.prototype.flatmap": "^1.3.1",
-        "array.prototype.tosorted": "^1.1.1",
-        "doctrine": "^2.1.0",
-        "es-iterator-helpers": "^1.0.12",
-        "estraverse": "^5.3.0",
-        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
-        "minimatch": "^3.1.2",
-        "object.entries": "^1.1.6",
-        "object.fromentries": "^2.0.6",
-        "object.hasown": "^1.1.2",
-        "object.values": "^1.1.6",
-        "prop-types": "^15.8.1",
-        "resolve": "^2.0.0-next.4",
-        "semver": "^6.3.1",
-        "string.prototype.matchall": "^4.0.8"
-      },
-      "dependencies": {
-        "doctrine": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
-          "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-          "dev": true,
-          "requires": {
-            "esutils": "^2.0.2"
-          }
-        },
-        "resolve": {
-          "version": "2.0.0-next.4",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.4.tgz",
-          "integrity": "sha512-iMDbmAWtfU+MHpxt/I5iWI7cY6YVEZUQ3MBgPQ++XD1PELuJHIl82xBmObyP2KyQmkNB2dsqF7seoQQiAn5yDQ==",
-          "dev": true,
-          "requires": {
-            "is-core-module": "^2.9.0",
-            "path-parse": "^1.0.7",
-            "supports-preserve-symlinks-flag": "^1.0.0"
-          }
-        }
-      }
-    },
-    "eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-      "dev": true,
-      "requires": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
-      }
-    },
-    "eslint-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-      "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
-      "dev": true,
-      "requires": {
-        "eslint-visitor-keys": "^2.0.0"
-      },
-      "dependencies": {
-        "eslint-visitor-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
-          "dev": true
-        }
-      }
-    },
-    "eslint-visitor-keys": {
-      "version": "3.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true
-    },
-    "espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-      "dev": true,
-      "requires": {
-        "acorn": "^8.9.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
-      }
-    },
-    "esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
-    },
-    "esquery": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-      "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
-      "dev": true,
-      "requires": {
-        "estraverse": "^5.1.0"
-      }
-    },
-    "esrecurse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
-      "requires": {
-        "estraverse": "^5.2.0"
-      }
-    },
-    "estraverse": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true
-    },
-    "esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
-    },
-    "event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="
-    },
-    "events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
-    },
-    "fast-deep-equal": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true
-    },
-    "fast-glob": {
-      "version": "3.2.12",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.12.tgz",
-      "integrity": "sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==",
-      "peer": true,
-      "requires": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "dependencies": {
-        "glob-parent": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-          "peer": true,
-          "requires": {
-            "is-glob": "^4.0.1"
-          }
-        }
-      }
-    },
-    "fast-json-stable-stringify": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true
-    },
-    "fastq": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
-      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
-      "requires": {
-        "reusify": "^1.0.4"
-      }
-    },
-    "fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
-    "file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "dev": true,
-      "requires": {
-        "flat-cache": "^3.0.4"
-      }
-    },
-    "fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "peer": true,
-      "requires": {
-        "to-regex-range": "^5.0.1"
-      }
-    },
-    "find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "requires": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      }
-    },
-    "flat-cache": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.0.4.tgz",
-      "integrity": "sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==",
-      "dev": true,
-      "requires": {
-        "flatted": "^3.1.0",
-        "rimraf": "^3.0.2"
-      }
-    },
-    "flatted": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
-      "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
-      "dev": true
-    },
-    "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.3"
-      }
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "requires": {
-        "fetch-blob": "^3.1.2"
-      }
-    },
-    "fs-extra": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "requires": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      }
-    },
-    "fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-      "dev": true
-    },
-    "function-bind": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true
-    },
-    "function.prototype.name": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.6.tgz",
-      "integrity": "sha512-Z5kx79swU5P27WEayXM1tBi5Ze/lbIyiNgU3qyXUOf9b2rgXYyF9Dy9Cx+IQv/Lc8WCG6L82zwUPpSS9hGehIg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "functions-have-names": "^1.2.3"
-      }
-    },
-    "functions-have-names": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
-      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
-      "dev": true
-    },
-    "get-intrinsic": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
-      "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
-      }
-    },
-    "get-stdin": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
-      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
-      "dev": true
-    },
-    "get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "requires": {
-        "pump": "^3.0.0"
-      }
-    },
-    "get-symbol-description": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.0.0.tgz",
-      "integrity": "sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
-      }
-    },
-    "glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      }
-    },
-    "glob-parent": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-      "dev": true,
-      "requires": {
-        "is-glob": "^4.0.3"
-      }
-    },
-    "globals": {
-      "version": "13.23.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-      "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
-      "dev": true,
-      "requires": {
-        "type-fest": "^0.20.2"
-      }
-    },
-    "globalthis": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
-      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3"
-      }
-    },
-    "gopd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.1.3"
-      }
-    },
-    "graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
-    },
-    "graphemer": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
-      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true
-    },
-    "has": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.1"
-      }
-    },
-    "has-bigints": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
-      "integrity": "sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==",
-      "dev": true
-    },
-    "has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true
-    },
-    "has-property-descriptors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-      "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.1.1"
-      }
-    },
-    "has-proto": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
-      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-      "dev": true
-    },
-    "has-symbols": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true
-    },
-    "has-tostringtag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.0.tgz",
-      "integrity": "sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.2"
-      }
-    },
-    "hasown": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
-      "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
-      "dev": true,
-      "requires": {
-        "function-bind": "^1.1.2"
-      }
-    },
-    "ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
-    },
-    "ignore": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-      "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
-      "dev": true
-    },
-    "import-fresh": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-      "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
-      "requires": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      }
-    },
-    "imurmurhash": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true
-    },
-    "inflight": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-      "dev": true,
-      "requires": {
-        "once": "^1.3.0",
-        "wrappy": "1"
-      }
-    },
-    "inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
-    "internal-slot": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
-      "integrity": "sha512-Xj6dv+PsbtwyPpEflsejS+oIZxmMlV44zAhG479uYu89MsjcYOhCFnNyKrkJrihbsiasQyY0afoCl/9BLR65bg==",
-      "dev": true,
-      "requires": {
-        "get-intrinsic": "^1.2.2",
-        "hasown": "^2.0.0",
-        "side-channel": "^1.0.4"
-      }
-    },
-    "is-array-buffer": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.2.tgz",
-      "integrity": "sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.0",
-        "is-typed-array": "^1.1.10"
-      }
-    },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "dev": true
-    },
-    "is-async-function": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.0.0.tgz",
-      "integrity": "sha512-Y1JXKrfykRJGdlDwdKlLpLyMIiWqWvuSd17TvZk68PLAOGOoF4Xyav1z0Xhoi+gCYjZVeC5SI+hYFOfvXmGRCA==",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-bigint": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.0.4.tgz",
-      "integrity": "sha512-zB9CruMamjym81i2JZ3UMn54PKGsQzsJeo6xvN3HJJ4CAsQNB6iRutp2To77OfCNuoxspsIhzaPoO1zyCEhFOg==",
-      "dev": true,
-      "requires": {
-        "has-bigints": "^1.0.1"
-      }
-    },
-    "is-boolean-object": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz",
-      "integrity": "sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-callable": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
-      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
-      "dev": true
-    },
-    "is-core-module": {
-      "version": "2.13.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
-      "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
-      "dev": true,
-      "requires": {
-        "hasown": "^2.0.0"
-      }
-    },
-    "is-date-object": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.5.tgz",
-      "integrity": "sha512-9YQaSxsAiSwcvS33MBk3wTCVnWK+HhF8VZR2jRxehM16QcVOdHqPn4VPHmRK4lSr38n9JriurInLcP90xsYNfQ==",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-extglob": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="
-    },
-    "is-finalizationregistry": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.0.2.tgz",
-      "integrity": "sha512-0by5vtUJs8iFQb5TYUHHPudOR+qXYIMKtiUzvLIZITZUjknFmziyBJuLhVRc+Ds0dREFlskDNJKYIdIzu/9pfw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2"
-      }
-    },
-    "is-generator-function": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.10.tgz",
-      "integrity": "sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-glob": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
-      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "requires": {
-        "is-extglob": "^2.1.1"
-      }
-    },
-    "is-map": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.2.tgz",
-      "integrity": "sha512-cOZFQQozTha1f4MxLFzlgKYPTyj26picdZTx82hbc/Xf4K/tZOOXSCkMvU4pKioRXGDLJRn0GM7Upe7kR721yg==",
-      "dev": true
-    },
-    "is-negative-zero": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.2.tgz",
-      "integrity": "sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==",
-      "dev": true
-    },
-    "is-number": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "peer": true
-    },
-    "is-number-object": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
-      "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true
-    },
-    "is-regex": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
-      "integrity": "sha512-kvRdxDsxZjhzUX07ZnLydzS1TU/TJlTUHHY4YLL87e37oUA49DfkLqgy+VjFocowy29cKvcSiu+kIv728jTTVg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-set": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
-      "integrity": "sha512-+2cnTEZeY5z/iXGbLhPrOAaK/Mau5k5eXq9j14CpRTftq0pAJu2MwVRSZhyZWBzx3o6X795Lz6Bpb6R0GKf37g==",
-      "dev": true
-    },
-    "is-shared-array-buffer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
-      "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2"
-      }
-    },
-    "is-string": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.7.tgz",
-      "integrity": "sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==",
-      "dev": true,
-      "requires": {
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "is-symbol": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.4.tgz",
-      "integrity": "sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==",
-      "dev": true,
-      "requires": {
-        "has-symbols": "^1.0.2"
-      }
-    },
-    "is-typed-array": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.12.tgz",
-      "integrity": "sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==",
-      "dev": true,
-      "requires": {
-        "which-typed-array": "^1.1.11"
-      }
-    },
-    "is-weakmap": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.1.tgz",
-      "integrity": "sha512-NSBR4kH5oVj1Uwvv970ruUkCV7O1mzgVFO4/rev2cLRda9Tm9HrL70ZPut4rOHgY0FNrUu9BCbXA2sdQ+x0chA==",
-      "dev": true
-    },
-    "is-weakref": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.0.2.tgz",
-      "integrity": "sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2"
-      }
-    },
-    "is-weakset": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.2.tgz",
-      "integrity": "sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.1"
-      }
-    },
-    "isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
-    },
-    "isexe": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-      "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
-    },
-    "iterator.prototype": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.2.tgz",
-      "integrity": "sha512-DR33HMMr8EzwuRL8Y9D3u2BMj8+RqSE850jfGu59kS7tbmPLzGkZmVSfyCFSDxuZiEY6Rzt3T2NA/qU+NwVj1w==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.2.1",
-        "get-intrinsic": "^1.2.1",
-        "has-symbols": "^1.0.3",
-        "reflect.getprototypeof": "^1.0.4",
-        "set-function-name": "^2.0.1"
-      }
-    },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
-    },
-    "js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
-      "requires": {
-        "argparse": "^2.0.1"
-      }
-    },
-    "json-parse-better-errors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-      "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-      "dev": true
-    },
-    "json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true
-    },
-    "json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
-      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true
-    },
-    "json5": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
-      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.0"
-      }
-    },
-    "jsonfile": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
-      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "requires": {
-        "graceful-fs": "^4.1.6",
-        "universalify": "^2.0.0"
-      }
-    },
-    "jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg=="
-    },
-    "jsonstream2": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonstream2/-/jsonstream2-3.0.0.tgz",
-      "integrity": "sha512-8ngq2XB8NjYrpe3+Xtl9lFJl6RoV2dNT4I7iyaHwxUpTBwsj0AlAR7epGfeYVP0z4Z7KxMoSxRgJWrd2jmBT/Q==",
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through2": "^3.0.1",
-        "type-component": "0.0.1"
-      }
-    },
-    "jsx-ast-utils": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.3.tgz",
-      "integrity": "sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==",
-      "dev": true,
-      "requires": {
-        "array-includes": "^3.1.5",
-        "object.assign": "^4.1.3"
-      }
-    },
-    "levn": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
-      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "^1.2.1",
-        "type-check": "~0.4.0"
-      }
-    },
-    "load-json-file": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-5.3.0.tgz",
-      "integrity": "sha512-cJGP40Jc/VXUsp8/OrnyKyTZ1y6v/dphm3bioS+RrKXjK2BB6wHUd6JptZEFDGgGahMT+InnZO5i1Ei9mpC8Bw==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.15",
-        "parse-json": "^4.0.0",
-        "pify": "^4.0.1",
-        "strip-bom": "^3.0.0",
-        "type-fest": "^0.3.0"
-      },
-      "dependencies": {
-        "type-fest": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
-          "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
-          "dev": true
-        }
-      }
-    },
-    "locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "requires": {
-        "p-locate": "^5.0.0"
-      }
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
-    "make-error": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "peer": true
-    },
-    "merge2": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-      "peer": true
-    },
-    "micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "peer": true,
-      "requires": {
-        "braces": "^3.0.2",
-        "picomatch": "^2.3.1"
-      }
-    },
-    "minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "^1.1.7"
-      }
-    },
-    "minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
-      "dev": true
-    },
-    "mkdirp": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "peer": true
-    },
-    "ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
-    },
-    "n3": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.16.3.tgz",
-      "integrity": "sha512-9caLSZuMW1kdlPxEN4ka6E4E8a5QKoZ2emxpW+zHMofI+Bo92nJhN//wNub15S5T9I4c6saEqdGEu+YXJqMZVA==",
-      "requires": {
-        "queue-microtask": "^1.1.2",
-        "readable-stream": "^4.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
-          "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10"
-          }
-        }
-      }
-    },
-    "natural-compare": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
-      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true
-    },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-    },
-    "node-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      }
-    },
-    "nodeify-fetch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/nodeify-fetch/-/nodeify-fetch-3.1.0.tgz",
-      "integrity": "sha512-ZV81vM//sEgTgXwVZlOONzcOCdTGQ53mV65FVSNXgPQHa8oCwRLtLbnGxL/1S/Yw90bcXUDKMz00jEnaeazo+A==",
-      "requires": {
-        "lodash": "^4.17.21",
-        "node-fetch": "^3.2.10",
-        "readable-stream": "^4.2.0",
-        "stream-chunks": "^1.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.2.0.tgz",
-          "integrity": "sha512-gJrBHsaI3lgBoGMW/jHZsQ/o/TIWiu5ENCJG1BB7fuCKzpFM8GaS2UoBVt9NO+oI+3FcrBNbUkl3ilDe09aY4A==",
-          "requires": {
-            "abort-controller": "^3.0.0",
-            "buffer": "^6.0.3",
-            "events": "^3.3.0",
-            "process": "^0.11.10"
-          }
-        }
-      }
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true
-    },
-    "object-inspect": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
-      "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
-      "dev": true
-    },
-    "object-keys": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
-    },
-    "object.assign": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-      "integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "has-symbols": "^1.0.3",
-        "object-keys": "^1.1.1"
-      }
-    },
-    "object.entries": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.6.tgz",
-      "integrity": "sha512-leTPzo4Zvg3pmbQ3rDK69Rl8GQvIqMWubrkxONG9/ojtFE2rD9fjMKfSI5BxW3osRH1m6VdzmqK8oAY9aT4x5w==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
-      }
-    },
-    "object.fromentries": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.7.tgz",
-      "integrity": "sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
-      }
-    },
-    "object.groupby": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.1.tgz",
-      "integrity": "sha512-HqaQtqLnp/8Bn4GL16cj+CUYbnpe1bh0TtEaWvybszDG4tgxCJuRpV8VGuvNaI1fAnI4lUJzDG55MXcOH4JZcQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1"
-      }
-    },
-    "object.hasown": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/object.hasown/-/object.hasown-1.1.2.tgz",
-      "integrity": "sha512-B5UIT3J1W+WuWIU55h0mjlwaqxiE5vYENJXIXZ4VFe05pNYrkKuK0U/6aFcb0pKywYJh7IhfoqUfKVmrJJHZHw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4"
-      }
-    },
-    "object.values": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.7.tgz",
-      "integrity": "sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
-      }
-    },
-    "once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "requires": {
-        "wrappy": "1"
-      }
-    },
-    "optionator": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-      "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
-      "dev": true,
-      "requires": {
-        "@aashutoshrathi/word-wrap": "^1.2.3",
-        "deep-is": "^0.1.3",
-        "fast-levenshtein": "^2.0.6",
-        "levn": "^0.4.1",
-        "prelude-ls": "^1.2.1",
-        "type-check": "^0.4.0"
-      }
-    },
-    "p-limit": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
-      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "requires": {
-        "yocto-queue": "^0.1.0"
-      }
-    },
-    "p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "requires": {
-        "p-limit": "^3.0.2"
-      }
-    },
-    "p-try": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-      "dev": true
-    },
-    "parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "requires": {
-        "callsites": "^3.0.0"
-      }
-    },
-    "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha512-aOIos8bujGN93/8Ox/jPLh7RwVnPEysynVFE+fQZyg6jKELEHwzgKdLRFHUgXJL6kylijVSBC4BvN9OmsB48Rw==",
-      "dev": true,
-      "requires": {
-        "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
-      }
-    },
-    "path-browserify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
-      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
-      "peer": true
-    },
-    "path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
-    },
-    "path-is-absolute": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-      "dev": true
-    },
-    "path-key": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
-    },
-    "path-parse": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "dev": true
-    },
-    "picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "peer": true
-    },
-    "pify": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-      "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-      "dev": true
-    },
-    "pkg-conf": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-conf/-/pkg-conf-3.1.0.tgz",
-      "integrity": "sha512-m0OTbR/5VPNPqO1ph6Fqbj7Hv6QU7gR/tQW40ZqrL1rjgCU85W6C1bJn0BItuJqnR98PWzw7Z8hHeChD1WrgdQ==",
-      "dev": true,
-      "requires": {
-        "find-up": "^3.0.0",
-        "load-json-file": "^5.2.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-          "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "path-exists": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-          "integrity": "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ==",
-          "dev": true
-        }
-      }
-    },
-    "pkg-dir": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
-      "integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
-      "requires": {
-        "find-up": "^5.0.0"
-      }
-    },
-    "prelude-ls": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
-      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="
-    },
-    "process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "promise-the-world": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/promise-the-world/-/promise-the-world-1.0.1.tgz",
-      "integrity": "sha512-eAXctcYU0ksq9YT5LT0N3e8yvdEAp0aYuzIiaJo9CpZwga45i08MW05GMXZIow7N05d1o4EBoR5hjkb7jhzqKg=="
-    },
-    "prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-      "requires": {
-        "end-of-stream": "^1.1.0",
-        "once": "^1.3.1"
-      }
-    },
-    "punycode": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
-      "dev": true
-    },
-    "queue-microtask": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
-    },
-    "rdf-canonize": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-3.3.0.tgz",
-      "integrity": "sha512-gfSNkMua/VWC1eYbSkVaL/9LQhFeOh0QULwv7Or0f+po8pMgQ1blYQFe1r9Mv2GJZXw88Cz/drnAnB9UlNnHfQ==",
-      "requires": {
-        "setimmediate": "^1.0.5"
-      }
-    },
-    "rdf-ext": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rdf-ext/-/rdf-ext-2.1.0.tgz",
-      "integrity": "sha512-gUm6wynD9o2odOvpr+hY0Gr8iH8NNpQytu6Hqp8oY5rkYImWjs9TGh8ioy/BXaxkzcKNmU8j6ovlFSSvxCMOwA==",
-      "requires": {
-        "@rdfjs/data-model": "^2.0.0",
-        "@rdfjs/dataset": "^2.0.0",
-        "@rdfjs/environment": "^0.1.0",
-        "@rdfjs/fetch-lite": "^3.1.0",
-        "@rdfjs/namespace": "^2.0.0",
-        "@rdfjs/normalize": "^2.0.0",
-        "@rdfjs/prefix-map": "^0.1.0",
-        "@rdfjs/score": "^0.1.1",
-        "@rdfjs/term-map": "^2.0.0",
-        "@rdfjs/term-set": "^2.0.0",
-        "@rdfjs/to-ntriples": "^2.0.0",
-        "@rdfjs/traverser": "^0.1.0",
-        "clownface": "^1.4.0",
-        "readable-stream": "^3.6.0"
-      },
-      "dependencies": {
-        "@rdfjs/data-model": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-2.0.1.tgz",
-          "integrity": "sha512-oRDYpy7/fJ9NNjS+M7m+dbnhi4lOWYGbBiM/A+u9bBExnN6ifXUF5mUsFxwZaQulmwTDaMhKERdV6iKTBUMgtw=="
-        },
-        "@rdfjs/namespace": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-2.0.0.tgz",
-          "integrity": "sha512-cBBvNrlSOah4z7u2vS74Lxng/ivELy6tNPjx+G/Ag14up8z5xmX8njn+U/mJ+nlcXO7nDGK4rgaAq7jtl9S3CQ==",
-          "requires": {
-            "@rdfjs/data-model": "^2.0.0"
-          }
-        },
-        "@rdfjs/term-map": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@rdfjs/term-map/-/term-map-2.0.0.tgz",
-          "integrity": "sha512-z0K8AgLsJGTrh+dGkXNl/oT9vBdMei4xq1MIeGN360oimA81Q+ruQUKFCbYNRRZS03tVHPBzqXUal/DezFGPEA==",
-          "requires": {
-            "@rdfjs/to-ntriples": "^2.0.0"
-          }
-        }
-      }
-    },
-    "rdf-js": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
-      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
-      "requires": {
-        "@rdfjs/types": "*"
-      }
-    },
-    "rdf-normalize": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/rdf-normalize/-/rdf-normalize-1.0.0.tgz",
-      "integrity": "sha512-1ocjoxovKc4+AyS4Tgtroay5R33yrtM2kQnAGvVaB0iGSRggukHxMJW0y8xTR7TwKZabS+7oMSQNMdbu/qTtCQ=="
-    },
-    "rdf-transform-triple-to-quad": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/rdf-transform-triple-to-quad/-/rdf-transform-triple-to-quad-1.0.2.tgz",
-      "integrity": "sha512-cr8wgJcj+SvPLichNhWhUTyXHcoD1EVgajVmvbtwYbMRw479KAaW03TTviQaJAUqgcWzIzkrWLtWkrY2FgwryQ==",
-      "requires": {
-        "@rdfjs/data-model": "^1.1.2",
-        "readable-stream": "^3.5.0"
-      }
-    },
-    "react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
-    },
-    "readable-error": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/readable-error/-/readable-error-1.0.0.tgz",
-      "integrity": "sha512-CLnInu5bUphmFiZ3pD/BC6+Cg4/BzK6ZMvWfd0b2QMzYo159Z/f/nVFQ9L5IeMrqUxy0EFsp3XJ+BRfLfY13IQ==",
-      "requires": {
-        "readable-stream": "^2.3.3"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "2.3.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.3",
-            "isarray": "~1.0.0",
-            "process-nextick-args": "~2.0.0",
-            "safe-buffer": "~5.1.1",
-            "string_decoder": "~1.1.1",
-            "util-deprecate": "~1.0.1"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "requires": {
-            "safe-buffer": "~5.1.0"
-          }
-        }
-      }
-    },
-    "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
-    "readable-to-readable": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/readable-to-readable/-/readable-to-readable-0.1.3.tgz",
-      "integrity": "sha512-G+0kz01xJM/uTuItKcqC73cifW8S6CZ7tp77NLN87lE5mrSU+GC8geoSAlfmp0NocmXckQ7W8s8ns73HYsIA3w==",
-      "requires": {
-        "readable-stream": "^3.6.0"
-      }
-    },
-    "reflect.getprototypeof": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.4.tgz",
-      "integrity": "sha512-ECkTw8TmJwW60lOTR+ZkODISW6RQ8+2CL3COqtiJKLd6MmB45hN51HprHFziKLGkAuTGQhBb91V8cy+KHlaCjw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1",
-        "get-intrinsic": "^1.2.1",
-        "globalthis": "^1.0.3",
-        "which-builtin-type": "^1.1.3"
-      }
-    },
-    "regexp.prototype.flags": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.1.tgz",
-      "integrity": "sha512-sy6TXMN+hnP/wMy+ISxg3krXx7BAtWVO4UouuCN/ziM9UEne0euamVNafDfvC83bRNr95y0V5iijeDQFUNpvrg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "set-function-name": "^2.0.0"
-      }
-    },
-    "regexpp": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
-      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
-      "dev": true
-    },
-    "resolve": {
-      "version": "1.22.8",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
-      "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
-      "dev": true,
-      "requires": {
-        "is-core-module": "^2.13.0",
-        "path-parse": "^1.0.7",
-        "supports-preserve-symlinks-flag": "^1.0.0"
-      }
-    },
-    "resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true
-    },
-    "reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
-    },
-    "rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "dev": true,
-      "requires": {
-        "glob": "^7.1.3"
-      }
-    },
-    "run-parallel": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
-      "requires": {
-        "queue-microtask": "^1.2.2"
-      }
-    },
-    "safe-array-concat": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.0.1.tgz",
-      "integrity": "sha512-6XbUAseYE2KtOuGueyeobCySj9L4+66Tn6KQMOPQJrAJEowYKW/YR/MGJZl7FdydUdaFu4LYyDZjxf4/Nmo23Q==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1",
-        "has-symbols": "^1.0.3",
-        "isarray": "^2.0.5"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
-        }
-      }
-    },
-    "safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
-    },
-    "safe-identifier": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/safe-identifier/-/safe-identifier-0.4.2.tgz",
-      "integrity": "sha512-6pNbSMW6OhAi9j+N8V+U715yBQsaWJ7eyEUaOrawX+isg5ZxhUlV1NipNtgaKHmFGiABwt+ZF04Ii+3Xjkg+8w==",
-      "peer": true
-    },
-    "safe-regex-test": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.0.0.tgz",
-      "integrity": "sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.1.3",
-        "is-regex": "^1.1.4"
-      }
-    },
-    "semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true
-    },
-    "separate-stream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/separate-stream/-/separate-stream-1.0.1.tgz",
-      "integrity": "sha512-UKFCzmddW2akOq40YdGehllv5gu6AD3y6nGSVuZuwI1kify2CiW7Zwsxx4ioaNLxx4LZaZMkcjdICHtSxpEpaA==",
-      "requires": {
-        "readable-stream": "^3.6.0"
-      }
-    },
-    "set-function-length": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
-      "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
-      "dev": true,
-      "requires": {
-        "define-data-property": "^1.1.1",
-        "get-intrinsic": "^1.2.1",
-        "gopd": "^1.0.1",
-        "has-property-descriptors": "^1.0.0"
-      }
-    },
-    "set-function-name": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.1.tgz",
-      "integrity": "sha512-tMNCiqYVkXIZgc2Hnoy2IvC/f8ezc5koaRFkCjrpWzGpCd3qbZXPzVy9MAZzK1ch/X0jvSkojys3oqJN0qCmdA==",
-      "dev": true,
-      "requires": {
-        "define-data-property": "^1.0.1",
-        "functions-have-names": "^1.2.3",
-        "has-property-descriptors": "^1.0.0"
-      }
-    },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
-    },
-    "shebang-command": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
-      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "^3.0.0"
-      }
-    },
-    "shebang-regex": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
-    },
-    "side-channel": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
-      "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.0",
-        "get-intrinsic": "^1.0.2",
-        "object-inspect": "^1.9.0"
-      }
-    },
-    "sparql-http-client": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/sparql-http-client/-/sparql-http-client-2.4.1.tgz",
-      "integrity": "sha512-w1rsSZW/0/byHml/veP4A1IZjEzjzphPr/iee1c20aG+RDEJC+2lAefXGTKZH58E7SSUoXqFW+hfwjVl5K2ecQ==",
-      "requires": {
-        "@rdfjs/data-model": "^1.1.2",
-        "@rdfjs/parser-n3": "^1.1.3",
-        "@rdfjs/to-ntriples": "^1.0.2",
-        "get-stream": "^5.1.0",
-        "jsonstream2": "^3.0.0",
-        "lodash": "^4.17.15",
-        "nodeify-fetch": "^2.2.0",
-        "promise-the-world": "^1.0.1",
-        "rdf-transform-triple-to-quad": "^1.0.2",
-        "readable-stream": "^3.5.0",
-        "separate-stream": "^1.0.0"
-      },
-      "dependencies": {
-        "@rdfjs/to-ntriples": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-1.0.2.tgz",
-          "integrity": "sha512-ngw5XAaGHjgGiwWWBPGlfdCclHftonmbje5lMys4G2j4NvfExraPIuRZgjSnd5lg4dnulRVUll8tRbgKO+7EDA=="
-        },
-        "nodeify-fetch": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/nodeify-fetch/-/nodeify-fetch-2.2.2.tgz",
-          "integrity": "sha512-4b1Jysy9RGyya0wJpseTQyxUgSbx6kw9ocHTY0OFRXWlxa2Uy5PrSo/P/nwoUn59rBR9YKty2kd7g4LKXmsZVA==",
-          "requires": {
-            "@zazuko/node-fetch": "^2.6.6",
-            "concat-stream": "^1.6.0",
-            "cross-fetch": "^3.0.4",
-            "readable-error": "^1.0.0",
-            "readable-stream": "^3.5.0"
-          }
-        }
-      }
-    },
-    "sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
-    },
-    "standard": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/standard/-/standard-17.1.0.tgz",
-      "integrity": "sha512-jaDqlNSzLtWYW4lvQmU0EnxWMUGQiwHasZl5ZEIwx3S/ijZDjZOzs1y1QqKwKs5vqnFpGtizo4NOYX2s0Voq/g==",
-      "dev": true,
-      "requires": {
-        "eslint": "^8.41.0",
-        "eslint-config-standard": "17.1.0",
-        "eslint-config-standard-jsx": "^11.0.0",
-        "eslint-plugin-import": "^2.27.5",
-        "eslint-plugin-n": "^15.7.0",
-        "eslint-plugin-promise": "^6.1.1",
-        "eslint-plugin-react": "^7.32.2",
-        "standard-engine": "^15.0.0",
-        "version-guard": "^1.1.1"
-      }
-    },
-    "standard-engine": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/standard-engine/-/standard-engine-15.0.0.tgz",
-      "integrity": "sha512-4xwUhJNo1g/L2cleysUqUv7/btn7GEbYJvmgKrQ2vd/8pkTmN8cpqAZg+BT8Z1hNeEH787iWUdOpL8fmApLtxA==",
-      "dev": true,
-      "requires": {
-        "get-stdin": "^8.0.0",
-        "minimist": "^1.2.6",
-        "pkg-conf": "^3.1.0",
-        "xdg-basedir": "^4.0.0"
-      }
-    },
-    "stream-chunks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-chunks/-/stream-chunks-1.0.0.tgz",
-      "integrity": "sha512-/G+kinLx3pKXChtuko82taA4gZo56zFG2b2BbhmugmS0TUPBL40c5b2vjonS+gAHYK/cSKM9m0WTvAJYgDUeNw==",
-      "requires": {
-        "buffer": "^6.0.3",
-        "string_decoder": "^1.3.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
-    "string-to-stream": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/string-to-stream/-/string-to-stream-3.0.1.tgz",
-      "integrity": "sha512-Hl092MV3USJuUCC6mfl9sPzGloA3K5VwdIeJjYIkXY/8K+mUvaeEabWJgArp+xXrsWxCajeT2pc4axbVhIZJyg==",
-      "requires": {
-        "readable-stream": "^3.4.0"
-      }
-    },
-    "string.prototype.matchall": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.8.tgz",
-      "integrity": "sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.1.4",
-        "es-abstract": "^1.20.4",
-        "get-intrinsic": "^1.1.3",
-        "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
-        "regexp.prototype.flags": "^1.4.3",
-        "side-channel": "^1.0.4"
-      }
-    },
-    "string.prototype.trim": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
-      "integrity": "sha512-lfjY4HcixfQXOfaqCvcBuOIapyaroTXhbkfJN3gcB1OtyupngWK4sEET9Knd0cXd28kTUqu/kHoV4HKSJdnjiQ==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
-      }
-    },
-    "string.prototype.trimend": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.7.tgz",
-      "integrity": "sha512-Ni79DqeB72ZFq1uH/L6zJ+DKZTkOtPIHovb3YZHQViE+HDouuU4mBrLOLDn5Dde3RF8qw5qVETEjhu9locMLvA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
-      }
-    },
-    "string.prototype.trimstart": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.7.tgz",
-      "integrity": "sha512-NGhtDFu3jCEm7B4Fy0DpLewdJQOZcQ0rGbwQ/+stjnrp2i+rlKeCvos9hOIeCmqwratM47OBxY7uFZzjxHXmrg==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "define-properties": "^1.2.0",
-        "es-abstract": "^1.22.1"
-      }
-    },
-    "strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "^5.0.1"
-      }
-    },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
-      "dev": true
-    },
-    "strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true
-    },
-    "supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "requires": {
-        "has-flag": "^4.0.0"
-      }
-    },
-    "supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
-      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
-      "dev": true
-    },
-    "text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
-    },
-    "through2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.2.tgz",
-      "integrity": "sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==",
-      "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "2 || 3"
-      }
-    },
-    "to-regex-range": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "peer": true,
-      "requires": {
-        "is-number": "^7.0.0"
-      }
-    },
-    "tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
-    },
-    "ts-morph": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-17.0.1.tgz",
-      "integrity": "sha512-10PkHyXmrtsTvZSL+cqtJLTgFXkU43Gd0JCc0Rw6GchWbqKe0Rwgt1v3ouobTZwQzF1mGhDeAlWYBMGRV7y+3g==",
-      "peer": true,
-      "requires": {
-        "@ts-morph/common": "~0.18.0",
-        "code-block-writer": "^11.0.3"
-      }
-    },
-    "ts-node": {
-      "version": "10.9.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-      "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "peer": true,
-      "requires": {
-        "@cspotcode/source-map-support": "^0.8.0",
-        "@tsconfig/node10": "^1.0.7",
-        "@tsconfig/node12": "^1.0.7",
-        "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.2",
-        "acorn": "^8.4.1",
-        "acorn-walk": "^8.1.1",
-        "arg": "^4.1.0",
-        "create-require": "^1.1.0",
-        "diff": "^4.0.1",
-        "make-error": "^1.1.1",
-        "v8-compile-cache-lib": "^3.0.1",
-        "yn": "3.1.1"
-      }
-    },
-    "tsconfig-paths": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.14.2.tgz",
-      "integrity": "sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==",
-      "dev": true,
-      "requires": {
-        "@types/json5": "^0.0.29",
-        "json5": "^1.0.2",
-        "minimist": "^1.2.6",
-        "strip-bom": "^3.0.0"
-      }
-    },
-    "type-check": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
-      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "^1.2.1"
-      }
-    },
-    "type-component": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/type-component/-/type-component-0.0.1.tgz",
-      "integrity": "sha512-mDZRBQS2yZkwRQKfjJvQ8UIYJeBNNWCq+HBNstl9N5s9jZ4dkVYXEGkVPsSCEh5Ld4JM1kmrZTzjnrqSAIQ7dw=="
-    },
-    "type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true
-    },
-    "typed-array-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.0.tgz",
-      "integrity": "sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "get-intrinsic": "^1.2.1",
-        "is-typed-array": "^1.1.10"
-      }
-    },
-    "typed-array-byte-length": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.0.tgz",
-      "integrity": "sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "has-proto": "^1.0.1",
-        "is-typed-array": "^1.1.10"
-      }
-    },
-    "typed-array-byte-offset": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.0.tgz",
-      "integrity": "sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==",
-      "dev": true,
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "has-proto": "^1.0.1",
-        "is-typed-array": "^1.1.10"
-      }
-    },
-    "typed-array-length": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
-      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "for-each": "^0.3.3",
-        "is-typed-array": "^1.1.9"
-      }
-    },
-    "typedarray": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
-    },
-    "typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
-      "peer": true
-    },
-    "unbox-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
-      "integrity": "sha512-61pPlCD9h51VoreyJ0BReideM3MDKMKnh6+V9L08331ipq6Q8OFXZYiqP6n/tbHx4s5I9uRhcye6BrbkizkBDw==",
-      "dev": true,
-      "requires": {
-        "call-bind": "^1.0.2",
-        "has-bigints": "^1.0.2",
-        "has-symbols": "^1.0.3",
-        "which-boxed-primitive": "^1.0.2"
-      }
-    },
-    "universalify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-      "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
-    },
-    "uri-js": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
-      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
-    },
-    "v8-compile-cache-lib": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "peer": true
-    },
-    "version-guard": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/version-guard/-/version-guard-1.1.1.tgz",
-      "integrity": "sha512-MGQLX89UxmYHgDvcXyjBI0cbmoW+t/dANDppNPrno64rYr8nH4SHSuElQuSYdXGEs0mUzdQe1BY+FhVPNsAmJQ==",
-      "dev": true
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
-    },
-    "webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
-    },
-    "whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "requires": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
-    },
-    "which": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
-      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
-      "requires": {
-        "isexe": "^2.0.0"
-      }
-    },
-    "which-boxed-primitive": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz",
-      "integrity": "sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==",
-      "dev": true,
-      "requires": {
-        "is-bigint": "^1.0.1",
-        "is-boolean-object": "^1.1.0",
-        "is-number-object": "^1.0.4",
-        "is-string": "^1.0.5",
-        "is-symbol": "^1.0.3"
-      }
-    },
-    "which-builtin-type": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.1.3.tgz",
-      "integrity": "sha512-YmjsSMDBYsM1CaFiayOVT06+KJeXf0o5M/CAd4o1lTadFAtacTUM49zoYxr/oroopFDfhvN6iEcBxUyc3gvKmw==",
-      "dev": true,
-      "requires": {
-        "function.prototype.name": "^1.1.5",
-        "has-tostringtag": "^1.0.0",
-        "is-async-function": "^2.0.0",
-        "is-date-object": "^1.0.5",
-        "is-finalizationregistry": "^1.0.2",
-        "is-generator-function": "^1.0.10",
-        "is-regex": "^1.1.4",
-        "is-weakref": "^1.0.2",
-        "isarray": "^2.0.5",
-        "which-boxed-primitive": "^1.0.2",
-        "which-collection": "^1.0.1",
-        "which-typed-array": "^1.1.9"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
-          "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-          "dev": true
-        }
-      }
-    },
-    "which-collection": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.1.tgz",
-      "integrity": "sha512-W8xeTUwaln8i3K/cY1nGXzdnVZlidBcagyNFtBdD5kxnb4TvGKR7FfSIS3mYpwWS1QUCutfKz8IY8RjftB0+1A==",
-      "dev": true,
-      "requires": {
-        "is-map": "^2.0.1",
-        "is-set": "^2.0.1",
-        "is-weakmap": "^2.0.1",
-        "is-weakset": "^2.0.1"
-      }
-    },
-    "which-typed-array": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
-      "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
-      "dev": true,
-      "requires": {
-        "available-typed-arrays": "^1.0.5",
-        "call-bind": "^1.0.4",
-        "for-each": "^0.3.3",
-        "gopd": "^1.0.1",
-        "has-tostringtag": "^1.0.0"
-      }
-    },
-    "wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
-    },
-    "xdg-basedir": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-4.0.0.tgz",
-      "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
-      "dev": true
-    },
-    "xmlbuilder2": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.0.2.tgz",
-      "integrity": "sha512-h4MUawGY21CTdhV4xm3DG9dgsqyhDkZvVJBx88beqX8wJs3VgyGQgAn5VreHuae6unTQxh115aMK5InCVmOIKw==",
-      "requires": {
-        "@oozcitak/dom": "1.15.10",
-        "@oozcitak/infra": "1.0.8",
-        "@oozcitak/util": "8.3.8",
-        "@types/node": "*",
-        "js-yaml": "3.14.0"
-      },
-      "dependencies": {
-        "argparse": {
-          "version": "1.0.10",
-          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-          "requires": {
-            "sprintf-js": "~1.0.2"
-          }
-        },
-        "js-yaml": {
-          "version": "3.14.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
-          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
-          "requires": {
-            "argparse": "^1.0.7",
-            "esprima": "^4.0.0"
-          }
-        }
-      }
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
-    },
-    "yn": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "peer": true
-    },
-    "yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@tpluscode/rdf-string": "^1.1.0",
     "@zazuko/env": "^1.8.0",
-    "@zazuko/vocabularies": "^2.0.3",
+    "@zazuko/prefixes": "^2.1.0",
     "dotenv": "^16.3.1",
     "sparql-http-client": "^2.4.2",
     "xmlbuilder2": "^3.1.1"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "@tpluscode/rdf-string": "^1.1.0",
-    "@zazuko/env": "^1.8.0",
+    "@zazuko/env": "^1.9.0",
     "@zazuko/prefixes": "^2.1.0",
     "dotenv": "^16.3.1",
     "sparql-http-client": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -10,12 +10,12 @@
   "author": "Zazuko GmbH",
   "license": "UNLICENSED",
   "dependencies": {
-    "@tpluscode/rdf-string": "^0.2.26",
-    "@zazuko/rdf-vocabularies": "2022.11.28",
-    "dotenv": "^16.0.3",
-    "rdf-ext": "^2.1.0",
-    "sparql-http-client": "^2.4.1",
-    "xmlbuilder2": "^3.0.2"
+    "@tpluscode/rdf-string": "^1.1.0",
+    "@zazuko/env": "^1.8.0",
+    "@zazuko/vocabularies": "^2.0.3",
+    "dotenv": "^16.3.1",
+    "sparql-http-client": "^2.4.2",
+    "xmlbuilder2": "^3.1.1"
   },
   "devDependencies": {
     "standard": "^17.1.0"

--- a/src/ckan.js
+++ b/src/ckan.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { toXML } from './xml.js'
 
 import { datasetsQuery } from './query.js'

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
+// @ts-check
 import { createAPI } from './ckan.js'
-import rdf from 'rdf-ext'
+import rdf from '@zazuko/env'
 
 const factory = (trifid) => {
   const { config, logger } = trifid

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -1,5 +1,5 @@
 import _rdf from '@zazuko/env'
-import { prefixes } from '@zazuko/vocabularies'
+import prefixes from '@zazuko/prefixes'
 
 export const dcat = _rdf.namespace(prefixes.dcat)
 export const dcterms = _rdf.namespace(prefixes.dcterms)

--- a/src/namespace.js
+++ b/src/namespace.js
@@ -1,5 +1,5 @@
-import _rdf from 'rdf-ext'
-import { prefixes } from '@zazuko/rdf-vocabularies'
+import _rdf from '@zazuko/env'
+import { prefixes } from '@zazuko/vocabularies'
 
 export const dcat = _rdf.namespace(prefixes.dcat)
 export const dcterms = _rdf.namespace(prefixes.dcterms)

--- a/src/query.js
+++ b/src/query.js
@@ -1,3 +1,4 @@
+// @ts-check
 import { sparql } from '@tpluscode/rdf-string'
 import * as ns from './namespace.js'
 

--- a/src/xml.js
+++ b/src/xml.js
@@ -1,6 +1,6 @@
 import rdf from '@zazuko/env'
 import * as ns from './namespace.js'
-import { prefixes, shrink } from '@zazuko/vocabularies'
+import prefixes, { shrink } from '@zazuko/prefixes'
 import { create as createXml } from 'xmlbuilder2'
 
 function toXML (dataset) {

--- a/src/xml.js
+++ b/src/xml.js
@@ -1,6 +1,6 @@
-import rdf from 'rdf-ext'
+import rdf from '@zazuko/env'
 import * as ns from './namespace.js'
-import { prefixes, shrink } from '@zazuko/rdf-vocabularies'
+import { prefixes, shrink } from '@zazuko/vocabularies'
 import { create as createXml } from 'xmlbuilder2'
 
 function toXML (dataset) {


### PR DESCRIPTION
This PR does the following:
- upgrade of some dependencies
- replace `@zazuko/rdf-vocabularies` with `@zazuko/vocabularies`
- replace `rdf-ext` with `@zazuko/env`